### PR TITLE
Allow zero value list elements

### DIFF
--- a/examples/testlib/fixtures/objects.tf
+++ b/examples/testlib/fixtures/objects.tf
@@ -5,7 +5,7 @@ resource "example_objects" "test" {
     float_value    = 0.75
     bool_value     = true
     enum_value     = 1
-    nullable_value = null
+    nullable_value = false
   }
 
   string_map = {
@@ -14,13 +14,13 @@ resource "example_objects" "test" {
   }
 
   int_map = {
-    one = 1
-    two = 2
+    key1 = 1
+    key2 = 2
   }
 
   bool_map = {
-    enabled  = true
-    disabled = false
+    key1 = true
+    key2 = false
   }
 
   nested_value = {
@@ -29,21 +29,31 @@ resource "example_objects" "test" {
     }
   }
 
-  nested_nullable = null
+  nested_nullable = {
+    leaf = {
+      value = "nested-value"
+    }
+  }
 
   nested_list = [
     { leaf = { value = "list-1" } },
     { leaf = { value = "list-2" } },
   ]
 
-  nested_nullable_list = null
+  nested_nullable_list = [
+    { leaf = { value = "list-1" } },
+    { leaf = { value = "list-2" } },
+  ]
 
   nested_map = {
-    first  = { leaf = { value = "map-1" } }
-    second = { leaf = { value = "map-2" } }
+    key1 = { leaf = { value = "map-1" } }
+    key2 = { leaf = { value = "map-2" } }
   }
 
-  nested_nullable_map = null
+  nested_nullable_map = {
+    key1 = { leaf = { value = "map-1" } }
+    key2 = { leaf = { value = "map-2" } }
+  }
 
   # oneof: set only one branch.
   branch1 = {

--- a/examples/testlib/fixtures/objects_zero_values.tf
+++ b/examples/testlib/fixtures/objects_zero_values.tf
@@ -1,0 +1,57 @@
+resource "example_objects" "test_zero_values" {
+  primitives = {
+    string_value   = ""
+    int32_value    = 0
+    float_value    = 0
+    bool_value     = false
+    enum_value     = 0
+    nullable_value = null
+  }
+
+  string_map = {
+    key1 = ""
+    key2 = ""
+  }
+
+  int_map = {
+    key1 = 0
+    key2 = 0
+  }
+
+  bool_map = {
+    key1 = false
+    key2 = false
+  }
+
+  nested_value = {
+    leaf = {
+      value = ""
+    }
+  }
+
+  nested_nullable = null
+
+  nested_list = [
+    { leaf = { value = "" } },
+    { leaf = { value = "" } },
+  ]
+
+  nested_nullable_list = null
+
+  nested_map = {
+    key1 = { leaf = { value = "" } }
+    key2 = { leaf = { value = "" } }
+  }
+
+  nested_nullable_map = null
+
+  branch1 = {
+    leaf = {
+      value = ""
+    }
+  }
+
+  leaf = {
+    value = ""
+  }
+}

--- a/examples/testlib/fixtures/objects_zero_values.tf
+++ b/examples/testlib/fixtures/objects_zero_values.tf
@@ -1,4 +1,4 @@
-resource "example_objects" "test_zero_values" {
+resource "example_objects" "test" {
   primitives = {
     string_value   = ""
     int32_value    = 0

--- a/examples/testlib/fixtures/primitives.tf
+++ b/examples/testlib/fixtures/primitives.tf
@@ -6,20 +6,17 @@ resource "example_primitives" "test" {
   // 0.75 works, but 0.76 fails.
   // Verify both cases are correctly validated after updating to > v1.2.0
   // See: https://github.com/hashicorp/terraform-plugin-framework/issues/647
-  float_value  = 0.75
-  double_value = 0.75
-  bool_value   = true
-  bytes_value  = "bytes"
-  enum_value   = 1
-  string_list  = ["el1", "el2"]
-  int32_list   = [123, 456]
-  int64_list   = [234, 567]
-  float_list   = [0.75, 1.25]
-  double_list  = [0.75, 1.25]
-  // TODO: Bool false value is treated as null within list.
-  // This should not be the case.
-  # bool_list        = [true, false]
-  bool_list      = [true]
+  float_value    = 0.75
+  double_value   = 0.75
+  bool_value     = true
+  bytes_value    = "bytes"
+  enum_value     = 1
+  string_list    = ["el1", "el2"]
+  int32_list     = [123, 456]
+  int64_list     = [234, 567]
+  float_list     = [0.75, 1.25]
+  double_list    = [0.75, 1.25]
+  bool_list      = [true, false]
   bytes_list     = ["bytes1", "bytes2"]
   enum_list      = [1, 2]
   nullable_value = null

--- a/examples/testlib/fixtures/primitives_zero_values.tf
+++ b/examples/testlib/fixtures/primitives_zero_values.tf
@@ -1,0 +1,19 @@
+resource "example_primitives" "test_zero_values" {
+  string_value   = ""
+  int32_value    = 0
+  int64_value    = 0
+  float_value    = 0
+  double_value   = 0
+  bool_value     = false
+  bytes_value    = ""
+  enum_value     = 0
+  string_list    = ["", ""]
+  int32_list     = [0, 0]
+  int64_list     = [0, 0]
+  float_list     = [0, 0]
+  double_list    = [0, 0]
+  bool_list      = [false, false]
+  bytes_list     = ["", ""]
+  enum_list      = [0, 0]
+  nullable_value = null
+}

--- a/examples/testlib/fixtures/primitives_zero_values.tf
+++ b/examples/testlib/fixtures/primitives_zero_values.tf
@@ -1,4 +1,4 @@
-resource "example_primitives" "test_zero_values" {
+resource "example_primitives" "test" {
   string_value   = ""
   int32_value    = 0
   int64_value    = 0

--- a/examples/testlib/fixtures/time_zero_values.tf
+++ b/examples/testlib/fixtures/time_zero_values.tf
@@ -1,4 +1,4 @@
-resource "example_time" "test_zero_values" {
+resource "example_time" "test" {
   duration_standard = "0s"
   duration_list     = ["0s", "0s"]
 

--- a/examples/testlib/fixtures/time_zero_values.tf
+++ b/examples/testlib/fixtures/time_zero_values.tf
@@ -1,0 +1,7 @@
+resource "example_time" "test_zero_values" {
+  duration_standard = "0s"
+  duration_list     = ["0s", "0s"]
+
+  duration_custom      = "0s"
+  duration_custom_list = ["0s", "0s"]
+}

--- a/examples/testlib/main_test.go
+++ b/examples/testlib/main_test.go
@@ -79,13 +79,53 @@ func (s *TerraformSuite) TestPrimitives() {
 					resource.TestCheckResourceAttr(name, "double_list.0", "0.75"),
 					resource.TestCheckResourceAttr(name, "double_list.1", "1.25"),
 					resource.TestCheckResourceAttr(name, "bool_list.0", "true"),
-					// TODO: Bool false value is treated as null within list.
-					// This should not be the case.
-					// resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
+					resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
 					resource.TestCheckResourceAttr(name, "bytes_list.0", "bytes1"),
 					resource.TestCheckResourceAttr(name, "bytes_list.1", "bytes2"),
 					resource.TestCheckResourceAttr(name, "enum_list.0", "1"),
 					resource.TestCheckResourceAttr(name, "enum_list.1", "2"),
+					resource.TestCheckNoResourceAttr(name, "nullable_value"),
+				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestPrimitivesZeroValues() {
+	t := s.T()
+	name := "example_primitives.test_zero_values"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("primitives_zero_values.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "string_value", ""),
+					resource.TestCheckResourceAttr(name, "int32_value", "0"),
+					resource.TestCheckResourceAttr(name, "int64_value", "0"),
+					resource.TestCheckResourceAttr(name, "float_value", "0"),
+					resource.TestCheckResourceAttr(name, "double_value", "0"),
+					resource.TestCheckResourceAttr(name, "bool_value", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_value", ""),
+					resource.TestCheckResourceAttr(name, "enum_value", "0"),
+					resource.TestCheckResourceAttr(name, "string_list.0", ""),
+					resource.TestCheckResourceAttr(name, "string_list.1", ""),
+					resource.TestCheckResourceAttr(name, "int32_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "int32_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "int64_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "int64_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "float_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "float_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "double_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "double_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "bool_list.0", "false"),
+					resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_list.0", ""),
+					resource.TestCheckResourceAttr(name, "bytes_list.1", ""),
+					resource.TestCheckResourceAttr(name, "enum_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "enum_list.1", "0"),
 					resource.TestCheckNoResourceAttr(name, "nullable_value"),
 				),
 			},
@@ -115,6 +155,30 @@ func (s *TerraformSuite) TestTime() {
 					resource.TestCheckResourceAttr(name, "duration_custom", "5m0s"),
 					resource.TestCheckResourceAttr(name, "duration_custom_list.0", "5m0s"),
 					resource.TestCheckResourceAttr(name, "duration_custom_list.1", "10m0s"),
+				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestTimeZeroValues() {
+	t := s.T()
+	time_zero_values := "example_time.test_zero_values"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("time_zero_values.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(time_zero_values, "duration_standard", "0s"),
+					resource.TestCheckResourceAttr(time_zero_values, "duration_list.0", "0s"),
+					resource.TestCheckResourceAttr(time_zero_values, "duration_list.1", "0s"),
+
+					resource.TestCheckResourceAttr(time_zero_values, "duration_custom", "0s"),
+					resource.TestCheckResourceAttr(time_zero_values, "duration_custom_list.0", "0s"),
+					resource.TestCheckResourceAttr(time_zero_values, "duration_custom_list.1", "0s"),
 				),
 			},
 		},
@@ -164,6 +228,52 @@ func (s *TerraformSuite) TestObjects() {
 					// TODO: Unepxected behavior with embedded fields.
 					// This embedded value overwrites the leaf.value field.
 					// resource.TestCheckResourceAttr(name, "value", "embedded-nullable-value"),
+				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestObjectsZeroValues() {
+	t := s.T()
+	name := "example_objects.test_zero_values"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("objects_zero_values.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "primitives.string_value", ""),
+					resource.TestCheckResourceAttr(name, "primitives.int32_value", "0"),
+					resource.TestCheckResourceAttr(name, "primitives.float_value", "0"),
+					resource.TestCheckResourceAttr(name, "primitives.bool_value", "false"),
+					resource.TestCheckResourceAttr(name, "primitives.enum_value", "0"),
+					resource.TestCheckNoResourceAttr(name, "primitives.nullable_value"),
+
+					resource.TestCheckResourceAttr(name, "string_map.key1", ""),
+					resource.TestCheckResourceAttr(name, "string_map.key2", ""),
+					resource.TestCheckResourceAttr(name, "int_map.key1", "0"),
+					resource.TestCheckResourceAttr(name, "int_map.key2", "0"),
+					resource.TestCheckResourceAttr(name, "bool_map.key1", "false"),
+					resource.TestCheckResourceAttr(name, "bool_map.key2", "false"),
+
+					resource.TestCheckResourceAttr(name, "nested_value.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable"),
+
+					resource.TestCheckResourceAttr(name, "nested_list.0.leaf.value", ""),
+					resource.TestCheckResourceAttr(name, "nested_list.1.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable_list"),
+
+					resource.TestCheckResourceAttr(name, "nested_map.key1.leaf.value", ""),
+					resource.TestCheckResourceAttr(name, "nested_map.key2.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable_map"),
+
+					resource.TestCheckResourceAttr(name, "branch1.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "branch2"),
+
+					resource.TestCheckResourceAttr(name, "leaf.value", ""),
 				),
 			},
 		},

--- a/examples/testlib/main_test.go
+++ b/examples/testlib/main_test.go
@@ -93,7 +93,7 @@ func (s *TerraformSuite) TestPrimitives() {
 
 func (s *TerraformSuite) TestPrimitivesZeroValues() {
 	t := s.T()
-	name := "example_primitives.test_zero_values"
+	name := "example_primitives.test"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
@@ -101,7 +101,7 @@ func (s *TerraformSuite) TestPrimitivesZeroValues() {
 		Steps: []resource.TestStep{
 			{
 				Config: s.getFixture("primitives_zero_values.tf"),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "string_value", ""),
 					resource.TestCheckResourceAttr(name, "int32_value", "0"),
 					resource.TestCheckResourceAttr(name, "int64_value", "0"),
@@ -128,6 +128,120 @@ func (s *TerraformSuite) TestPrimitivesZeroValues() {
 					resource.TestCheckResourceAttr(name, "enum_list.1", "0"),
 					resource.TestCheckNoResourceAttr(name, "nullable_value"),
 				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestPrimitivesUpdate() {
+	t := s.T()
+	name := "example_primitives.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("primitives.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "string_value", "string"),
+					resource.TestCheckResourceAttr(name, "int32_value", "123"),
+					resource.TestCheckResourceAttr(name, "int64_value", "456"),
+					resource.TestCheckResourceAttr(name, "float_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "double_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "bool_value", "true"),
+					resource.TestCheckResourceAttr(name, "bytes_value", "bytes"),
+					resource.TestCheckResourceAttr(name, "enum_value", "1"),
+					resource.TestCheckResourceAttr(name, "string_list.0", "el1"),
+					resource.TestCheckResourceAttr(name, "string_list.1", "el2"),
+					resource.TestCheckResourceAttr(name, "int32_list.0", "123"),
+					resource.TestCheckResourceAttr(name, "int32_list.1", "456"),
+					resource.TestCheckResourceAttr(name, "int64_list.0", "234"),
+					resource.TestCheckResourceAttr(name, "int64_list.1", "567"),
+					resource.TestCheckResourceAttr(name, "float_list.0", "0.75"),
+					resource.TestCheckResourceAttr(name, "float_list.1", "1.25"),
+					resource.TestCheckResourceAttr(name, "double_list.0", "0.75"),
+					resource.TestCheckResourceAttr(name, "double_list.1", "1.25"),
+					resource.TestCheckResourceAttr(name, "bool_list.0", "true"),
+					resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_list.0", "bytes1"),
+					resource.TestCheckResourceAttr(name, "bytes_list.1", "bytes2"),
+					resource.TestCheckResourceAttr(name, "enum_list.0", "1"),
+					resource.TestCheckResourceAttr(name, "enum_list.1", "2"),
+					resource.TestCheckNoResourceAttr(name, "nullable_value"),
+				),
+			},
+			{
+				Config:   s.getFixture("primitives.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("primitives_zero_values.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "string_value", ""),
+					resource.TestCheckResourceAttr(name, "int32_value", "0"),
+					resource.TestCheckResourceAttr(name, "int64_value", "0"),
+					resource.TestCheckResourceAttr(name, "float_value", "0"),
+					resource.TestCheckResourceAttr(name, "double_value", "0"),
+					resource.TestCheckResourceAttr(name, "bool_value", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_value", ""),
+					resource.TestCheckResourceAttr(name, "enum_value", "0"),
+					resource.TestCheckResourceAttr(name, "string_list.0", ""),
+					resource.TestCheckResourceAttr(name, "string_list.1", ""),
+					resource.TestCheckResourceAttr(name, "int32_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "int32_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "int64_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "int64_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "float_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "float_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "double_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "double_list.1", "0"),
+					resource.TestCheckResourceAttr(name, "bool_list.0", "false"),
+					resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_list.0", ""),
+					resource.TestCheckResourceAttr(name, "bytes_list.1", ""),
+					resource.TestCheckResourceAttr(name, "enum_list.0", "0"),
+					resource.TestCheckResourceAttr(name, "enum_list.1", "0"),
+					resource.TestCheckNoResourceAttr(name, "nullable_value"),
+				),
+			},
+			{
+				Config:   s.getFixture("primitives_zero_values.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("primitives.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "string_value", "string"),
+					resource.TestCheckResourceAttr(name, "int32_value", "123"),
+					resource.TestCheckResourceAttr(name, "int64_value", "456"),
+					resource.TestCheckResourceAttr(name, "float_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "double_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "bool_value", "true"),
+					resource.TestCheckResourceAttr(name, "bytes_value", "bytes"),
+					resource.TestCheckResourceAttr(name, "enum_value", "1"),
+					resource.TestCheckResourceAttr(name, "string_list.0", "el1"),
+					resource.TestCheckResourceAttr(name, "string_list.1", "el2"),
+					resource.TestCheckResourceAttr(name, "int32_list.0", "123"),
+					resource.TestCheckResourceAttr(name, "int32_list.1", "456"),
+					resource.TestCheckResourceAttr(name, "int64_list.0", "234"),
+					resource.TestCheckResourceAttr(name, "int64_list.1", "567"),
+					resource.TestCheckResourceAttr(name, "float_list.0", "0.75"),
+					resource.TestCheckResourceAttr(name, "float_list.1", "1.25"),
+					resource.TestCheckResourceAttr(name, "double_list.0", "0.75"),
+					resource.TestCheckResourceAttr(name, "double_list.1", "1.25"),
+					resource.TestCheckResourceAttr(name, "bool_list.0", "true"),
+					resource.TestCheckResourceAttr(name, "bool_list.1", "false"),
+					resource.TestCheckResourceAttr(name, "bytes_list.0", "bytes1"),
+					resource.TestCheckResourceAttr(name, "bytes_list.1", "bytes2"),
+					resource.TestCheckResourceAttr(name, "enum_list.0", "1"),
+					resource.TestCheckResourceAttr(name, "enum_list.1", "2"),
+					resource.TestCheckNoResourceAttr(name, "nullable_value"),
+				),
+			},
+			{
+				Config:   s.getFixture("primitives.tf"),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -163,7 +277,7 @@ func (s *TerraformSuite) TestTime() {
 
 func (s *TerraformSuite) TestTimeZeroValues() {
 	t := s.T()
-	time_zero_values := "example_time.test_zero_values"
+	name := "example_time.test"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
@@ -172,14 +286,86 @@ func (s *TerraformSuite) TestTimeZeroValues() {
 			{
 				Config: s.getFixture("time_zero_values.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(time_zero_values, "duration_standard", "0s"),
-					resource.TestCheckResourceAttr(time_zero_values, "duration_list.0", "0s"),
-					resource.TestCheckResourceAttr(time_zero_values, "duration_list.1", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_standard", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.0", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.1", "0s"),
 
-					resource.TestCheckResourceAttr(time_zero_values, "duration_custom", "0s"),
-					resource.TestCheckResourceAttr(time_zero_values, "duration_custom_list.0", "0s"),
-					resource.TestCheckResourceAttr(time_zero_values, "duration_custom_list.1", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.0", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.1", "0s"),
 				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestTimeUpdate() {
+	t := s.T()
+	name := "example_time.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("time.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "timestamp_value", "2026-01-02T03:04:05Z"),
+					resource.TestCheckResourceAttr(name, "timestamp_list.0", "2026-01-02T03:04:05Z"),
+					resource.TestCheckResourceAttr(name, "timestamp_list.1", "2026-01-02T03:04:06Z"),
+
+					resource.TestCheckResourceAttr(name, "duration_standard", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.0", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.1", "10m0s"),
+
+					resource.TestCheckResourceAttr(name, "duration_custom", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.0", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.1", "10m0s"),
+				),
+			},
+			{
+				Config:   s.getFixture("time.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("time_zero_values.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(name, "timestamp_value"),
+					resource.TestCheckNoResourceAttr(name, "timestamp_list.0"),
+					resource.TestCheckNoResourceAttr(name, "timestamp_list.1"),
+
+					resource.TestCheckResourceAttr(name, "duration_standard", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.0", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.1", "0s"),
+
+					resource.TestCheckResourceAttr(name, "duration_custom", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.0", "0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.1", "0s"),
+				),
+			},
+			{
+				Config:   s.getFixture("time_zero_values.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("time.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "timestamp_value", "2026-01-02T03:04:05Z"),
+					resource.TestCheckResourceAttr(name, "timestamp_list.0", "2026-01-02T03:04:05Z"),
+					resource.TestCheckResourceAttr(name, "timestamp_list.1", "2026-01-02T03:04:06Z"),
+
+					resource.TestCheckResourceAttr(name, "duration_standard", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.0", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_list.1", "10m0s"),
+
+					resource.TestCheckResourceAttr(name, "duration_custom", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.0", "5m0s"),
+					resource.TestCheckResourceAttr(name, "duration_custom_list.1", "10m0s"),
+				),
+			},
+			{
+				Config:   s.getFixture("time.tf"),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -201,25 +387,27 @@ func (s *TerraformSuite) TestObjects() {
 					resource.TestCheckResourceAttr(name, "primitives.float_value", "0.75"),
 					resource.TestCheckResourceAttr(name, "primitives.bool_value", "true"),
 					resource.TestCheckResourceAttr(name, "primitives.enum_value", "1"),
-					resource.TestCheckNoResourceAttr(name, "primitives.nullable_value"),
+					resource.TestCheckResourceAttr(name, "primitives.nullable_value", "false"),
 
 					resource.TestCheckResourceAttr(name, "string_map.key1", "value1"),
 					resource.TestCheckResourceAttr(name, "string_map.key2", "value2"),
-					resource.TestCheckResourceAttr(name, "int_map.one", "1"),
-					resource.TestCheckResourceAttr(name, "int_map.two", "2"),
-					resource.TestCheckResourceAttr(name, "bool_map.enabled", "true"),
-					resource.TestCheckResourceAttr(name, "bool_map.disabled", "false"),
+					resource.TestCheckResourceAttr(name, "int_map.key1", "1"),
+					resource.TestCheckResourceAttr(name, "int_map.key2", "2"),
+					resource.TestCheckResourceAttr(name, "bool_map.key1", "true"),
+					resource.TestCheckResourceAttr(name, "bool_map.key2", "false"),
 
 					resource.TestCheckResourceAttr(name, "nested_value.leaf.value", "nested-value"),
-					resource.TestCheckNoResourceAttr(name, "nested_nullable"),
+					resource.TestCheckResourceAttr(name, "nested_nullable.leaf.value", "nested-value"),
 
 					resource.TestCheckResourceAttr(name, "nested_list.0.leaf.value", "list-1"),
 					resource.TestCheckResourceAttr(name, "nested_list.1.leaf.value", "list-2"),
-					resource.TestCheckNoResourceAttr(name, "nested_nullable_list"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.0.leaf.value", "list-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.1.leaf.value", "list-2"),
 
-					resource.TestCheckResourceAttr(name, "nested_map.first.leaf.value", "map-1"),
-					resource.TestCheckResourceAttr(name, "nested_map.second.leaf.value", "map-2"),
-					resource.TestCheckNoResourceAttr(name, "nested_nullable_map"),
+					resource.TestCheckResourceAttr(name, "nested_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_map.key2.leaf.value", "map-2"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key2.leaf.value", "map-2"),
 
 					resource.TestCheckResourceAttr(name, "branch1.leaf.value", "branch-1"),
 					resource.TestCheckNoResourceAttr(name, "branch2"),
@@ -236,7 +424,7 @@ func (s *TerraformSuite) TestObjects() {
 
 func (s *TerraformSuite) TestObjectsZeroValues() {
 	t := s.T()
-	name := "example_objects.test_zero_values"
+	name := "example_objects.test"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: s.terraformProviders,
@@ -244,7 +432,7 @@ func (s *TerraformSuite) TestObjectsZeroValues() {
 		Steps: []resource.TestStep{
 			{
 				Config: s.getFixture("objects_zero_values.tf"),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "primitives.string_value", ""),
 					resource.TestCheckResourceAttr(name, "primitives.int32_value", "0"),
 					resource.TestCheckResourceAttr(name, "primitives.float_value", "0"),
@@ -275,6 +463,136 @@ func (s *TerraformSuite) TestObjectsZeroValues() {
 
 					resource.TestCheckResourceAttr(name, "leaf.value", ""),
 				),
+			},
+		},
+	})
+}
+
+func (s *TerraformSuite) TestObjectsUpdate() {
+	t := s.T()
+	name := "example_objects.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("objects.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "primitives.string_value", "string"),
+					resource.TestCheckResourceAttr(name, "primitives.int32_value", "123"),
+					resource.TestCheckResourceAttr(name, "primitives.float_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "primitives.bool_value", "true"),
+					resource.TestCheckResourceAttr(name, "primitives.enum_value", "1"),
+					resource.TestCheckResourceAttr(name, "primitives.nullable_value", "false"),
+
+					resource.TestCheckResourceAttr(name, "string_map.key1", "value1"),
+					resource.TestCheckResourceAttr(name, "string_map.key2", "value2"),
+					resource.TestCheckResourceAttr(name, "int_map.key1", "1"),
+					resource.TestCheckResourceAttr(name, "int_map.key2", "2"),
+					resource.TestCheckResourceAttr(name, "bool_map.key1", "true"),
+					resource.TestCheckResourceAttr(name, "bool_map.key2", "false"),
+
+					resource.TestCheckResourceAttr(name, "nested_value.leaf.value", "nested-value"),
+					resource.TestCheckResourceAttr(name, "nested_nullable.leaf.value", "nested-value"),
+
+					resource.TestCheckResourceAttr(name, "nested_list.0.leaf.value", "list-1"),
+					resource.TestCheckResourceAttr(name, "nested_list.1.leaf.value", "list-2"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.0.leaf.value", "list-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.1.leaf.value", "list-2"),
+
+					resource.TestCheckResourceAttr(name, "nested_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_map.key2.leaf.value", "map-2"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key2.leaf.value", "map-2"),
+
+					resource.TestCheckResourceAttr(name, "branch1.leaf.value", "branch-1"),
+					resource.TestCheckNoResourceAttr(name, "branch2"),
+
+					resource.TestCheckResourceAttr(name, "leaf.value", "embedded-leaf"),
+				),
+			},
+			{
+				Config:   s.getFixture("objects.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("objects_zero_values.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "primitives.string_value", ""),
+					resource.TestCheckResourceAttr(name, "primitives.int32_value", "0"),
+					resource.TestCheckResourceAttr(name, "primitives.float_value", "0"),
+					resource.TestCheckResourceAttr(name, "primitives.bool_value", "false"),
+					resource.TestCheckResourceAttr(name, "primitives.enum_value", "0"),
+					resource.TestCheckNoResourceAttr(name, "primitives.nullable_value"),
+
+					resource.TestCheckResourceAttr(name, "string_map.key1", ""),
+					resource.TestCheckResourceAttr(name, "string_map.key2", ""),
+					resource.TestCheckResourceAttr(name, "int_map.key1", "0"),
+					resource.TestCheckResourceAttr(name, "int_map.key2", "0"),
+					resource.TestCheckResourceAttr(name, "bool_map.key1", "false"),
+					resource.TestCheckResourceAttr(name, "bool_map.key2", "false"),
+
+					resource.TestCheckResourceAttr(name, "nested_value.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable"),
+
+					resource.TestCheckResourceAttr(name, "nested_list.0.leaf.value", ""),
+					resource.TestCheckResourceAttr(name, "nested_list.1.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable_list"),
+
+					resource.TestCheckResourceAttr(name, "nested_map.key1.leaf.value", ""),
+					resource.TestCheckResourceAttr(name, "nested_map.key2.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "nested_nullable_map"),
+
+					resource.TestCheckResourceAttr(name, "branch1.leaf.value", ""),
+					resource.TestCheckNoResourceAttr(name, "branch2"),
+
+					resource.TestCheckResourceAttr(name, "leaf.value", ""),
+				),
+			},
+			{
+				Config:   s.getFixture("objects_zero_values.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("objects.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "primitives.string_value", "string"),
+					resource.TestCheckResourceAttr(name, "primitives.int32_value", "123"),
+					resource.TestCheckResourceAttr(name, "primitives.float_value", "0.75"),
+					resource.TestCheckResourceAttr(name, "primitives.bool_value", "true"),
+					resource.TestCheckResourceAttr(name, "primitives.enum_value", "1"),
+					resource.TestCheckResourceAttr(name, "primitives.nullable_value", "false"),
+
+					resource.TestCheckResourceAttr(name, "string_map.key1", "value1"),
+					resource.TestCheckResourceAttr(name, "string_map.key2", "value2"),
+					resource.TestCheckResourceAttr(name, "int_map.key1", "1"),
+					resource.TestCheckResourceAttr(name, "int_map.key2", "2"),
+					resource.TestCheckResourceAttr(name, "bool_map.key1", "true"),
+					resource.TestCheckResourceAttr(name, "bool_map.key2", "false"),
+
+					resource.TestCheckResourceAttr(name, "nested_value.leaf.value", "nested-value"),
+					resource.TestCheckResourceAttr(name, "nested_nullable.leaf.value", "nested-value"),
+
+					resource.TestCheckResourceAttr(name, "nested_list.0.leaf.value", "list-1"),
+					resource.TestCheckResourceAttr(name, "nested_list.1.leaf.value", "list-2"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.0.leaf.value", "list-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_list.1.leaf.value", "list-2"),
+
+					resource.TestCheckResourceAttr(name, "nested_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_map.key2.leaf.value", "map-2"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key1.leaf.value", "map-1"),
+					resource.TestCheckResourceAttr(name, "nested_nullable_map.key2.leaf.value", "map-2"),
+
+					resource.TestCheckResourceAttr(name, "branch1.leaf.value", "branch-1"),
+					resource.TestCheckNoResourceAttr(name, "branch2"),
+
+					resource.TestCheckResourceAttr(name, "leaf.value", "embedded-leaf"),
+				),
+			},
+			{
+				Config:   s.getFixture("objects.tf"),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/examples/tfschema/custom/v1/custom_terraform.go
+++ b/examples/tfschema/custom/v1/custom_terraform.go
@@ -306,6 +306,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["computed"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["computed"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.computed", "obj.Computed"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.computed", err})
@@ -328,6 +331,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["id"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.id", "obj.Id"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.id", err})
@@ -350,6 +356,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["custom_name_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["custom_name_override"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.name_override", "obj.NameOverride"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.name_override", err})
@@ -372,6 +381,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["plan_modifier"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["plan_modifier"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.plan_modifier", "obj.PlanModifier"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.plan_modifier", err})
@@ -394,6 +406,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["required"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["required"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.required", "obj.Required"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.required", err})
@@ -416,6 +431,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["schema_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["schema_override"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.schema_override", "obj.SchemaOverride"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.schema_override", err})
@@ -438,6 +456,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["sensitive"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["sensitive"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.sensitive", "obj.Sensitive"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.sensitive", err})
@@ -469,6 +490,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 		} else {
 			v, ok := tf.Attrs["validated"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["validated"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Custom.validated", "obj.Validated"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Custom.validated", err})

--- a/examples/tfschema/custom/v1/custom_terraform.go
+++ b/examples/tfschema/custom/v1/custom_terraform.go
@@ -307,7 +307,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["computed"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["computed"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.computed", "obj.Computed"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.computed", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -332,7 +332,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["id"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.id", "obj.Id"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -357,7 +357,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["custom_name_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["custom_name_override"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.name_override", "obj.NameOverride"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.name_override", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -382,7 +382,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["plan_modifier"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["plan_modifier"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.plan_modifier", "obj.PlanModifier"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.plan_modifier", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -407,7 +407,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["required"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["required"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.required", "obj.Required"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.required", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -432,7 +432,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["schema_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["schema_override"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.schema_override", "obj.SchemaOverride"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.schema_override", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -457,7 +457,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["sensitive"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["sensitive"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.sensitive", "obj.Sensitive"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.sensitive", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -491,7 +491,7 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 			v, ok := tf.Attrs["validated"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["validated"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Custom.validated", "obj.Validated"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Custom.validated", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -616,5 +616,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1372,7 +1372,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Objects.bool_map", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.bool_map", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1461,7 +1461,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
 												if tf.Attrs["value"] != nil {
-													diags.Append(attrWriteConversionFailureDiag{"Objects.branch1.leaf.value", "obj.Value"})
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.branch1.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
@@ -1554,7 +1554,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
 												if tf.Attrs["value"] != nil {
-													diags.Append(attrWriteConversionFailureDiag{"Objects.branch2.leaf.value", "obj.Value"})
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.branch2.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
@@ -1616,7 +1616,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["active"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
 								if tf.Attrs["active"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.empty.active", "obj.active"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.empty.active", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -1646,7 +1646,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["id"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Objects.id", "obj.Id"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -1691,7 +1691,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Objects.int_map", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.int_map", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1750,7 +1750,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.leaf.value", "obj.Value"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -1850,7 +1850,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["value"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_list.leaf.value", "obj.Value"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_list.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -1960,7 +1960,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["value"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_map.leaf.value", "obj.Value"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_map.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -2056,7 +2056,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
 												if tf.Attrs["value"] != nil {
-													diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable.leaf.value", "obj.Value"})
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_nullable.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
@@ -2164,7 +2164,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["value"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable_list.leaf.value", "obj.Value"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_nullable_list.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -2276,7 +2276,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["value"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable_map.leaf.value", "obj.Value"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_nullable_map.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -2370,7 +2370,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
 												if tf.Attrs["value"] != nil {
-													diags.Append(attrWriteConversionFailureDiag{"Objects.nested_value.leaf.value", "obj.Value"})
+													diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.nested_value.leaf.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
@@ -2456,7 +2456,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2489,7 +2489,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["bool_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
 								if tf.Attrs["bool_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_value", "obj.BoolValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.bool_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2537,7 +2537,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bytes_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.bytes_list", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2570,7 +2570,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["bytes_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["bytes_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bytes_value", "obj.BytesValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.bytes_value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2618,7 +2618,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.double_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.double_list", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2651,7 +2651,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["double_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 							if !ok {
 								if tf.Attrs["double_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.double_value", "obj.DoubleValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.double_value", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2699,7 +2699,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.enum_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.enum_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2732,7 +2732,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["enum_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
 								if tf.Attrs["enum_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.enum_value", "obj.EnumValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.enum_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2780,7 +2780,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.float_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.float_list", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2813,7 +2813,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["float_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 							if !ok {
 								if tf.Attrs["float_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.float_value", "obj.FloatValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.float_value", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2838,7 +2838,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["id"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.id", "obj.Id"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2886,7 +2886,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int32_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.int32_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2919,7 +2919,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["int32_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
 								if tf.Attrs["int32_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int32_value", "obj.Int32Value"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.int32_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2967,7 +2967,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int64_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.int64_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -3000,7 +3000,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["int64_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
 								if tf.Attrs["int64_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int64_value", "obj.Int64Value"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.int64_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -3025,7 +3025,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["nullable_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
 								if tf.Attrs["nullable_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.nullable_value", "obj.NullableValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.nullable_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -3073,7 +3073,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.string_list", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.string_list", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -3106,7 +3106,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 							v, ok := tf.Attrs["string_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["string_value"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.string_value", "obj.StringValue"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.primitives.string_value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -3157,7 +3157,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Objects.string_map", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.string_map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -3190,7 +3190,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 			v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Objects.value", "obj.Value"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Objects.value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -3319,5 +3319,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1369,7 +1369,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				if obj.BoolMap != nil {
 					t := o.ElemType
 					for k, a := range obj.BoolMap {
-						v, ok := tf.Attrs["bool_map"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1673,7 +1673,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				if obj.IntMap != nil {
 					t := o.ElemType
 					for k, a := range obj.IntMap {
-						v, ok := tf.Attrs["int_map"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1780,7 +1780,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 					for k, a := range obj.NestedList {
-						v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -1887,7 +1887,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				if obj.NestedMap != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedMap {
-						v, ok := tf.Attrs["nested_map"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -2083,7 +2083,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
 					}
 					for k, a := range obj.NestedNullableList {
-						v, ok := tf.Attrs["nested_nullable_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -2192,7 +2192,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				if obj.NestedNullableMap != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedNullableMap {
-						v, ok := tf.Attrs["nested_nullable_map"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -2414,7 +2414,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 									for k, a := range obj.BoolList {
-										v, ok := tf.Attrs["bool_list"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2489,7 +2489,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 									}
 									for k, a := range obj.BytesList {
-										v, ok := tf.Attrs["bytes_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2564,7 +2564,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 									}
 									for k, a := range obj.DoubleList {
-										v, ok := tf.Attrs["double_list"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2639,7 +2639,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 									}
 									for k, a := range obj.EnumList {
-										v, ok := tf.Attrs["enum_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2714,7 +2714,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 									for k, a := range obj.FloatList {
-										v, ok := tf.Attrs["float_list"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2811,7 +2811,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 									}
 									for k, a := range obj.Int32List {
-										v, ok := tf.Attrs["int32_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2886,7 +2886,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 									for k, a := range obj.Int64List {
-										v, ok := tf.Attrs["int64_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -2983,7 +2983,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 									for k, a := range obj.StringList {
-										v, ok := tf.Attrs["string_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -3061,7 +3061,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				if obj.StringMap != nil {
 					t := o.ElemType
 					for k, a := range obj.StringMap {
-						v, ok := tf.Attrs["string_map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1371,6 +1371,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					for k, a := range obj.BoolMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Objects.bool_map", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Objects.bool_map", err})
@@ -1457,6 +1460,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										} else {
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["value"] != nil {
+													diags.Append(attrWriteConversionFailureDiag{"Objects.branch1.leaf.value", "obj.Value"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"Objects.branch1.leaf.value", err})
@@ -1547,6 +1553,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										} else {
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["value"] != nil {
+													diags.Append(attrWriteConversionFailureDiag{"Objects.branch2.leaf.value", "obj.Value"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"Objects.branch2.leaf.value", err})
@@ -1606,6 +1615,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["active"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
+								if tf.Attrs["active"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.empty.active", "obj.active"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.empty.active", err})
@@ -1633,6 +1645,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 		} else {
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["id"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Objects.id", "obj.Id"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Objects.id", err})
@@ -1675,6 +1690,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					for k, a := range obj.IntMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Objects.int_map", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Objects.int_map", err})
@@ -1731,6 +1749,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.leaf.value", "obj.Value"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.leaf.value", err})
@@ -1828,6 +1849,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 												} else {
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["value"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_list.leaf.value", "obj.Value"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Objects.nested_list.leaf.value", err})
@@ -1935,6 +1959,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 												} else {
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["value"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_map.leaf.value", "obj.Value"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Objects.nested_map.leaf.value", err})
@@ -2028,6 +2055,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										} else {
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["value"] != nil {
+													diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable.leaf.value", "obj.Value"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"Objects.nested_nullable.leaf.value", err})
@@ -2133,6 +2163,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 												} else {
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["value"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable_list.leaf.value", "obj.Value"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Objects.nested_nullable_list.leaf.value", err})
@@ -2242,6 +2275,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 												} else {
 													v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["value"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Objects.nested_nullable_map.leaf.value", "obj.Value"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Objects.nested_nullable_map.leaf.value", err})
@@ -2333,6 +2369,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										} else {
 											v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 											if !ok {
+												if tf.Attrs["value"] != nil {
+													diags.Append(attrWriteConversionFailureDiag{"Objects.nested_value.leaf.value", "obj.Value"})
+												}
 												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 												if err != nil {
 													diags.Append(attrWriteGeneralError{"Objects.nested_value.leaf.value", err})
@@ -2416,6 +2455,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.BoolList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.bool_list", err})
@@ -2446,6 +2488,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["bool_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
+								if tf.Attrs["bool_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_value", "obj.BoolValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.bool_value", err})
@@ -2491,6 +2536,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.BytesList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bytes_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.bytes_list", err})
@@ -2521,6 +2569,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["bytes_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["bytes_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bytes_value", "obj.BytesValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.bytes_value", err})
@@ -2566,6 +2617,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.DoubleList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.double_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.double_list", err})
@@ -2596,6 +2650,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["double_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 							if !ok {
+								if tf.Attrs["double_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.double_value", "obj.DoubleValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.double_value", err})
@@ -2641,6 +2698,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.EnumList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.enum_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.enum_list", err})
@@ -2671,6 +2731,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["enum_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
+								if tf.Attrs["enum_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.enum_value", "obj.EnumValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.enum_value", err})
@@ -2716,6 +2779,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.FloatList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.float_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.float_list", err})
@@ -2746,6 +2812,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["float_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 							if !ok {
+								if tf.Attrs["float_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.float_value", "obj.FloatValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.float_value", err})
@@ -2768,6 +2837,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["id"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.id", "obj.Id"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.id", err})
@@ -2813,6 +2885,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.Int32List {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int32_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.int32_list", err})
@@ -2843,6 +2918,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["int32_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
+								if tf.Attrs["int32_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int32_value", "obj.Int32Value"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.int32_value", err})
@@ -2888,6 +2966,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.Int64List {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int64_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.int64_list", err})
@@ -2918,6 +2999,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["int64_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
+								if tf.Attrs["int64_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.int64_value", "obj.Int64Value"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.int64_value", err})
@@ -2940,6 +3024,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["nullable_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
+								if tf.Attrs["nullable_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.nullable_value", "obj.NullableValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.nullable_value", err})
@@ -2985,6 +3072,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 									for k, a := range obj.StringList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.string_list", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Objects.primitives.string_list", err})
@@ -3015,6 +3105,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						} else {
 							v, ok := tf.Attrs["string_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["string_value"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.string_value", "obj.StringValue"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Objects.primitives.string_value", err})
@@ -3063,6 +3156,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					for k, a := range obj.StringMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Objects.string_map", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Objects.string_map", err})
@@ -3093,6 +3189,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 		} else {
 			v, ok := tf.Attrs["value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Objects.value", "obj.Value"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Objects.value", err})

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -566,6 +566,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.BoolList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.bool_list", err})
@@ -596,6 +599,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["bool_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
+				if tf.Attrs["bool_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_value", "obj.BoolValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.bool_value", err})
@@ -641,6 +647,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.BytesList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.bytes_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.bytes_list", err})
@@ -671,6 +680,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["bytes_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["bytes_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.bytes_value", "obj.BytesValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.bytes_value", err})
@@ -716,6 +728,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.DoubleList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.double_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.double_list", err})
@@ -746,6 +761,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["double_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
+				if tf.Attrs["double_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.double_value", "obj.DoubleValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.double_value", err})
@@ -791,6 +809,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.EnumList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.enum_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.enum_list", err})
@@ -821,6 +842,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["enum_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["enum_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.enum_value", "obj.EnumValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.enum_value", err})
@@ -866,6 +890,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.FloatList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.float_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.float_list", err})
@@ -896,6 +923,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["float_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
+				if tf.Attrs["float_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.float_value", "obj.FloatValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.float_value", err})
@@ -918,6 +948,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["id"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.id", "obj.Id"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.id", err})
@@ -963,6 +996,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.Int32List {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.int32_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.int32_list", err})
@@ -993,6 +1029,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["int32_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["int32_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.int32_value", "obj.Int32Value"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.int32_value", err})
@@ -1038,6 +1077,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.Int64List {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.int64_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.int64_list", err})
@@ -1068,6 +1110,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["int64_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["int64_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.int64_value", "obj.Int64Value"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.int64_value", err})
@@ -1090,6 +1135,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["nullable_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
+				if tf.Attrs["nullable_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.nullable_value", "obj.NullableValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.nullable_value", err})
@@ -1135,6 +1183,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 					for k, a := range obj.StringList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Primitives.string_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Primitives.string_list", err})
@@ -1165,6 +1216,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 		} else {
 			v, ok := tf.Attrs["string_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["string_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Primitives.string_value", "obj.StringValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Primitives.string_value", err})

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -567,7 +567,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -600,7 +600,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["bool_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
 				if tf.Attrs["bool_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_value", "obj.BoolValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.bool_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -648,7 +648,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.bytes_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.bytes_list", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -681,7 +681,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["bytes_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["bytes_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.bytes_value", "obj.BytesValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.bytes_value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -729,7 +729,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.double_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.double_list", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -762,7 +762,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["double_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
 				if tf.Attrs["double_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.double_value", "obj.DoubleValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.double_value", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -810,7 +810,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.enum_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.enum_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -843,7 +843,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["enum_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["enum_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.enum_value", "obj.EnumValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.enum_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -891,7 +891,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.float_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.float_list", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -924,7 +924,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["float_value"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
 				if tf.Attrs["float_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.float_value", "obj.FloatValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.float_value", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -949,7 +949,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["id"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.id", "obj.Id"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -997,7 +997,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.int32_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.int32_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1030,7 +1030,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["int32_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["int32_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.int32_value", "obj.Int32Value"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.int32_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -1078,7 +1078,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.int64_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.int64_list", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1111,7 +1111,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["int64_value"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["int64_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.int64_value", "obj.Int64Value"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.int64_value", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -1136,7 +1136,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["nullable_value"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
 				if tf.Attrs["nullable_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.nullable_value", "obj.NullableValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.nullable_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -1184,7 +1184,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Primitives.string_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.string_list", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1217,7 +1217,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 			v, ok := tf.Attrs["string_value"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["string_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Primitives.string_value", "obj.StringValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Primitives.string_value", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -1342,5 +1342,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -564,7 +564,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 					}
 					for k, a := range obj.BoolList {
-						v, ok := tf.Attrs["bool_list"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -639,7 +639,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 					for k, a := range obj.BytesList {
-						v, ok := tf.Attrs["bytes_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -714,7 +714,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 					}
 					for k, a := range obj.DoubleList {
-						v, ok := tf.Attrs["double_list"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -789,7 +789,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 					}
 					for k, a := range obj.EnumList {
-						v, ok := tf.Attrs["enum_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -864,7 +864,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 					}
 					for k, a := range obj.FloatList {
-						v, ok := tf.Attrs["float_list"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -961,7 +961,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 					}
 					for k, a := range obj.Int32List {
-						v, ok := tf.Attrs["int32_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1036,7 +1036,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 					}
 					for k, a := range obj.Int64List {
-						v, ok := tf.Attrs["int64_list"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -1133,7 +1133,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 					for k, a := range obj.StringList {
-						v, ok := tf.Attrs["string_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -255,6 +255,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 		} else {
 			v, ok := tf.Attrs["duration_custom"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_custom"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Time.duration_custom", "obj.DurationCustom"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Time.duration_custom", err})
@@ -300,6 +303,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 					for k, a := range obj.DurationCustomList {
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Time.duration_custom_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Time.duration_custom_list", err})
@@ -353,6 +359,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 					for k, a := range obj.DurationList {
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Time.duration_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Time.duration_list", err})
@@ -383,6 +392,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 		} else {
 			v, ok := tf.Attrs["duration_standard"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_standard"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Time.duration_standard", "obj.DurationStandard"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Time.duration_standard", err})
@@ -405,6 +417,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 		} else {
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["id"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Time.id", "obj.Id"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Time.id", err})
@@ -450,6 +465,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 					for k, a := range obj.TimestampList {
 						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Time.timestamp_list", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Time.timestamp_list", err})
@@ -480,6 +498,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 		} else {
 			v, ok := tf.Attrs["timestamp_value"].(TimeValue)
 			if !ok {
+				if tf.Attrs["timestamp_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Time.timestamp_value", "obj.TimestampValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Time.timestamp_value", err})

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -298,7 +298,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 					for k, a := range obj.DurationCustomList {
-						v, ok := tf.Attrs["duration_custom_list"].(DurationValue)
+						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -351,7 +351,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
 					}
 					for k, a := range obj.DurationList {
-						v, ok := tf.Attrs["duration_list"].(DurationValue)
+						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -448,7 +448,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 					for k, a := range obj.TimestampList {
-						v, ok := tf.Attrs["timestamp_list"].(TimeValue)
+						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -256,7 +256,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 			v, ok := tf.Attrs["duration_custom"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_custom"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Time.duration_custom", "obj.DurationCustom"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.duration_custom", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -304,7 +304,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Time.duration_custom_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.duration_custom_list", "DurationValue"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -360,7 +360,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Time.duration_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.duration_list", "DurationValue"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -393,7 +393,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 			v, ok := tf.Attrs["duration_standard"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_standard"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Time.duration_standard", "obj.DurationStandard"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.duration_standard", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -418,7 +418,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 			v, ok := tf.Attrs["id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["id"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Time.id", "obj.Id"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -466,7 +466,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Time.timestamp_list", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.timestamp_list", "TimeValue"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -499,7 +499,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 			v, ok := tf.Attrs["timestamp_value"].(TimeValue)
 			if !ok {
 				if tf.Attrs["timestamp_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Time.timestamp_value", "obj.TimestampValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Time.timestamp_value", "TimeValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -624,5 +624,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -154,8 +154,21 @@ func (f *FieldCopyToGenerator) genZeroValue(fieldName string) func(*j.Group) {
 
 // genPrimitiveBody generates a block statement that reads an object field into
 // variable "v".
-func (f *FieldCopyToGenerator) genPrimitiveBody(g *j.Group, fieldName string) {
-	g.If(j.Id("!ok")).BlockFunc(f.genZeroValue(fieldName))
+func (f *FieldCopyToGenerator) genPrimitiveBody(g *j.Group, fieldName string, existing *j.Statement, expectedType string) {
+	g.If(j.Id("!ok")).BlockFunc(
+		// If the existing field is not of the expected primitive type.
+		// This is either because the field is uninitialized, but this could be a bug.
+		func(g *j.Group) {
+			// First we check if the field was really uninitialized.
+			// If it's not, we don't know what's going on and need to fail.
+			g.If(existing.Op("!=").Nil()).Block(
+				j.Id("diags.Append").Call(
+					j.Id("attrWriteUnexpectedExistingTypeDiag").Values(j.Lit(f.Path), j.Lit(expectedType)),
+				),
+			)
+			// The existing field is nil, we generate the zero value.
+			f.genZeroValue(fieldName)(g)
+		})
 
 	if !f.IsPlaceholder {
 		if f.ParentIsOptionalEmbed {
@@ -246,8 +259,10 @@ func (f *FieldCopyToGenerator) genPrimitive() *j.Statement {
 			f.genOneOfStub(g)
 		}
 
-		f.getAttr(g, "v", "tf.Attrs", f.i.WithType(f.Field.ElemValueType), j.Lit(f.Field.NameSnake))
-		f.genPrimitiveBody(g, fieldName)
+		selector := "tf.Attrs"
+		index := j.Lit(f.Field.NameSnake)
+		f.getAttr(g, "v", selector, f.i.WithType(f.Field.ElemValueType), index)
+		f.genPrimitiveBody(g, fieldName, j.Id(selector).Index(index), f.Field.ElemValueType)
 		g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("v")
 	})
 }
@@ -332,8 +347,10 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 				g.For(j.List(j.Id("k"), j.Id("a"))).Op(":=").Range().Id(fieldName).BlockFunc(func(g *j.Group) {
 					switch f.Kind {
 					case PrimitiveListKind, PrimitiveMapKind:
-						f.getAttr(g, "v", "c.Elems", f.i.WithType(f.Field.ElemValueType), j.Id("k"))
-						f.genPrimitiveBody(g, "a")
+						selector := "c.Elems"
+						index := j.Id("k")
+						f.getAttr(g, "v", selector, f.i.WithType(f.Field.ElemValueType), index)
+						f.genPrimitiveBody(g, "a", j.Id(selector).Index(index), f.Field.ElemValueType)
 					default:
 						m := NewMessageCopyToGenerator(f.getValueField().Message, f.i)
 						f.getAttr(g, "v", "c.Elems", f.i.WithType(f.Field.ElemValueType), j.Id("k"))

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -104,13 +104,15 @@ func (f *FieldCopyToGenerator) nextField(v string, g func(g *j.Group)) *j.Statem
 	)
 }
 
-// getAttr v, ok := tf.Attrs["name"]
-func (f *FieldCopyToGenerator) getAttr(v string, typ string, g *j.Group) {
-	g.List(
-		j.Id(v), j.Id("ok"),
-	).Op(":=").Id("tf.Attrs").Index(
-		j.Lit(f.Field.NameSnake),
-	).Assert(j.Id(f.i.WithType(typ)))
+// getAttr generates a statement to read the value of an attribute at the specified index.
+//
+// Expected format: `<varName>, ok := <selector>[<index>].(valType)`
+func (f *FieldCopyToGenerator) getAttr(g *j.Group, varName, selector, valType string, index *j.Statement) {
+	g.List(j.Id(varName), j.Id("ok")).
+		Op(":=").
+		Id(selector).
+		Index(index).
+		Assert(j.Id(f.i.WithType(valType)))
 }
 
 // genZeroValue generates zero value from an empty AttrType
@@ -150,9 +152,9 @@ func (f *FieldCopyToGenerator) genZeroValue(fieldName string) func(*j.Group) {
 	}
 }
 
-// genPrimitiveBody generates block which reads object field into v
-func (f *FieldCopyToGenerator) genPrimitiveBody(fieldName string, g *j.Group) {
-	f.getAttr("v", f.i.WithType(f.Field.ElemValueType), g)
+// genPrimitiveBody generates a block statement that reads an object field into
+// variable "v".
+func (f *FieldCopyToGenerator) genPrimitiveBody(g *j.Group, fieldName string) {
 	g.If(j.Id("!ok")).BlockFunc(f.genZeroValue(fieldName))
 
 	if !f.IsPlaceholder {
@@ -180,8 +182,9 @@ func (f *FieldCopyToGenerator) genAssignValue(fieldName string) *j.Statement {
 	return j.Id("v.Value").Op("=").Id(f.i.WithType(f.ValueCastToType)).Parens(j.Id(fieldName))
 }
 
-// genObjectBody generates block which reads message into v
-func (f *FieldCopyToGenerator) genObjectBody(m *MessageCopyToGenerator, fieldName string, typ string, g *j.Group) {
+// genObjectBody generates block statement that reads a message into
+// variable "v".
+func (f *FieldCopyToGenerator) genObjectBody(g *j.Group, m *MessageCopyToGenerator, fieldName string, typ string) {
 	copyObj := func(g *j.Group) {
 		if len(m.Fields) > 0 {
 			if !m.IsEmpty {
@@ -192,7 +195,6 @@ func (f *FieldCopyToGenerator) genObjectBody(m *MessageCopyToGenerator, fieldNam
 		}
 	}
 
-	f.getAttr("v", f.Field.ElemValueType, g)
 	g.If(j.Id("!ok")).Block(
 		// v := types.Object{Attrs: make(map[string]attr.Value, len(o.AttrTypes)), AttrTypes: o.AttrTypes}
 		j.Id("v").Op("=").Id(f.i.WithType(typ)).Block(j.Dict{
@@ -244,7 +246,8 @@ func (f *FieldCopyToGenerator) genPrimitive() *j.Statement {
 			f.genOneOfStub(g)
 		}
 
-		f.genPrimitiveBody(fieldName, g)
+		f.getAttr(g, "v", "tf.Attrs", f.i.WithType(f.Field.ElemValueType), j.Lit(f.Field.NameSnake))
+		f.genPrimitiveBody(g, fieldName)
 		g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("v")
 	})
 }
@@ -260,7 +263,8 @@ func (f *FieldCopyToGenerator) genObject() *j.Statement {
 		}
 
 		f.assertTo(f.Field.ElemType, g, func(g *j.Group) {
-			f.genObjectBody(m, fieldName, f.Field.ValueType, g)
+			f.getAttr(g, "v", "tf.Attrs", f.i.WithType(f.Field.ElemValueType), j.Lit(f.Field.NameSnake))
+			f.genObjectBody(g, m, fieldName, f.Field.ValueType)
 			g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("v")
 		})
 	})
@@ -293,7 +297,7 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 
 	return f.nextField("a", func(g *j.Group) {
 		f.assertTo(f.Field.Type, g, func(g *j.Group) {
-			f.getAttr("c", f.Field.ValueType, g)
+			f.getAttr(g, "c", "tf.Attrs", f.Field.ValueType, j.Lit(f.Field.NameSnake))
 
 			g.If(j.Id("!ok")).Block(
 				// c := types.Object{Elems: make([]attr.Value, ElemType: o.ElemType}
@@ -326,11 +330,14 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 
 				// for k, a := range obj.List
 				g.For(j.List(j.Id("k"), j.Id("a"))).Op(":=").Range().Id(fieldName).BlockFunc(func(g *j.Group) {
-					if (f.Kind == PrimitiveListKind) || (f.Kind == PrimitiveMapKind) {
-						f.genPrimitiveBody("a", g)
-					} else {
+					switch f.Kind {
+					case PrimitiveListKind, PrimitiveMapKind:
+						f.getAttr(g, "v", "c.Elems", f.i.WithType(f.Field.ElemValueType), j.Id("k"))
+						f.genPrimitiveBody(g, "a")
+					default:
 						m := NewMessageCopyToGenerator(f.getValueField().Message, f.i)
-						f.genObjectBody(m, "a", f.i.WithType(f.Field.ElemValueType), g)
+						f.getAttr(g, "v", "c.Elems", f.i.WithType(f.Field.ElemValueType), j.Id("k"))
+						f.genObjectBody(g, m, "a", f.i.WithType(f.Field.ElemValueType))
 					}
 					g.Id("c.Elems").Index(j.Id("k")).Op("=").Id("v")
 				})

--- a/shared_code.go.tpl
+++ b/shared_code.go.tpl
@@ -105,3 +105,26 @@ func (d attrWriteGeneralError) Detail() string {
 func (d attrWriteGeneralError) Equal(o diag.Diagnostic) bool {
     return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() diag.Severity {
+	return diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2566,7 +2566,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 					for k, a := range obj.BytesList {
-						v, ok := tf.Attrs["bytes_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -2663,7 +2663,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 					for k, a := range obj.DurationCustomList {
-						v, ok := tf.Attrs["duration_custom_list"].(DurationValue)
+						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -3003,7 +3003,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				if obj.Map != nil {
 					t := o.ElemType
 					for k, a := range obj.Map {
-						v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -3053,7 +3053,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				if obj.MapObject != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObject {
-						v, ok := tf.Attrs["map_object"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3093,7 +3093,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.Map != nil {
 											t := o.ElemType
 											for k, a := range obj.Map {
-												v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -3143,7 +3143,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
-												v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3221,7 +3221,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 											for k, a := range obj.NestedList {
-												v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3333,7 +3333,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				if obj.MapObjectNullable != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObjectNullable {
-						v, ok := tf.Attrs["map_object_nullable"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3375,7 +3375,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.Map != nil {
 											t := o.ElemType
 											for k, a := range obj.Map {
-												v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -3425,7 +3425,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
-												v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3503,7 +3503,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 											for k, a := range obj.NestedList {
-												v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3661,7 +3661,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.Map != nil {
 									t := o.ElemType
 									for k, a := range obj.Map {
-										v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -3711,7 +3711,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
-										v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3789,7 +3789,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 									for k, a := range obj.NestedList {
-										v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3897,7 +3897,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 					for k, a := range obj.NestedList {
-						v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -3937,7 +3937,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.Map != nil {
 											t := o.ElemType
 											for k, a := range obj.Map {
-												v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -3987,7 +3987,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
-												v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4065,7 +4065,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 											for k, a := range obj.NestedList {
-												v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4180,7 +4180,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
 					}
 					for k, a := range obj.NestedListNullable {
-						v, ok := tf.Attrs["nested_list_nullable"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
 							v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4222,7 +4222,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.Map != nil {
 											t := o.ElemType
 											for k, a := range obj.Map {
-												v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -4272,7 +4272,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
-												v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4350,7 +4350,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 											for k, a := range obj.NestedList {
-												v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
 													v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4488,7 +4488,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.Map != nil {
 									t := o.ElemType
 									for k, a := range obj.Map {
-										v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -4538,7 +4538,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
-										v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4616,7 +4616,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 									for k, a := range obj.NestedList {
-										v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4747,7 +4747,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.Map != nil {
 									t := o.ElemType
 									for k, a := range obj.Map {
-										v, ok := tf.Attrs["map"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -4797,7 +4797,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
-										v, ok := tf.Attrs["map_object_nested"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -4875,7 +4875,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 									for k, a := range obj.NestedList {
-										v, ok := tf.Attrs["nested_list"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
 											v = github_com_hashicorp_terraform_plugin_framework_types.Object{
 
@@ -5053,7 +5053,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 					for k, a := range obj.StringList {
-						v, ok := tf.Attrs["string_list"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -5106,7 +5106,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
 					}
 					for k, a := range obj.StringListEmpty {
-						v, ok := tf.Attrs["string_list_empty"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -5190,7 +5190,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 					for k, a := range obj.TimestampList {
-						v, ok := tf.Attrs["timestamp_list"].(TimeValue)
+						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2329,7 +2329,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["bar"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["bar"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.bar", "obj.Bar"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.bar", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2354,7 +2354,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["bool"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
 				if tf.Attrs["bool"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Bool", "obj.Bool"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Bool", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2418,7 +2418,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["str"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.Branch1.Str", "obj.Str"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Branch1.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2479,7 +2479,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["int32"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
 								if tf.Attrs["int32"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.Branch2.Int32", "obj.Int32"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Branch2.Int32", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2514,7 +2514,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["branch3"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["branch3"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Branch3", "obj.Branch3"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Branch3", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2539,7 +2539,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["bytes"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["bytes"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.bytes", "obj.Bytes"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.bytes", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2587,7 +2587,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.BytesList", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.BytesList", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -2620,7 +2620,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["double"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
 				if tf.Attrs["double"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Double", "obj.Double"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Double", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2645,7 +2645,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["duration_custom"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_custom"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustom", "obj.DurationCustom"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.DurationCustom", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2693,7 +2693,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustomList", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.DurationCustomList", "DurationValue"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -2726,7 +2726,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["duration_custom_missing"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_custom_missing"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustomMissing", "obj.DurationCustomMissing"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.DurationCustomMissing", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2751,7 +2751,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["duration_standard"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_standard"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.DurationStandard", "obj.DurationStandard"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.DurationStandard", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2776,7 +2776,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["duration_standard_missing"].(DurationValue)
 			if !ok {
 				if tf.Attrs["duration_standard_missing"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.DurationStandardMissing", "obj.DurationStandardMissing"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.DurationStandardMissing", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2827,7 +2827,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["embedded_nested_string"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["embedded_nested_string"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.EmbeddedNestedField.EmbeddedNestedString", "obj.EmbeddedNestedString"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.EmbeddedNestedField.EmbeddedNestedString", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2858,7 +2858,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["embedded_string"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["embedded_string"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.EmbeddedString", "obj.EmbeddedString"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.EmbeddedString", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2912,7 +2912,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["active"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
 								if tf.Attrs["active"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.EmptyMessageBranch.active", "obj.active"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.EmptyMessageBranch.active", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -2942,7 +2942,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["float"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
 				if tf.Attrs["float"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Float", "obj.Float"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Float", "github.com/hashicorp/terraform-plugin-framework/types.Float64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2971,7 +2971,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["foo"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["foo"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.foo", "obj.Foo"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.foo", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -2996,7 +2996,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["int32"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["int32"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Int32", "obj.Int32"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Int32", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -3021,7 +3021,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["int64"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["int64"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Int64", "obj.Int64"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Int64", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -3066,7 +3066,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.Map", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -3159,7 +3159,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													if c.Elems[k] != nil {
-														diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.Map", "a"})
+														diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObject.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -3232,7 +3232,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.MapObjectNested.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObject.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -3315,7 +3315,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.NestedList.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObject.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -3353,7 +3353,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
 										if tf.Attrs["str"] != nil {
-											diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.Str", "obj.Str"})
+											diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObject.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
@@ -3453,7 +3453,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													if c.Elems[k] != nil {
-														diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.Map", "a"})
+														diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObjectNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -3526,7 +3526,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.MapObjectNested.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObjectNullable.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -3609,7 +3609,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.NestedList.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObjectNullable.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -3647,7 +3647,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
 										if tf.Attrs["str"] != nil {
-											diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.Str", "obj.Str"})
+											diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.MapObjectNullable.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
@@ -3685,7 +3685,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
 				if tf.Attrs["mode"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Mode", "obj.Mode"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Mode", "github.com/hashicorp/terraform-plugin-framework/types.Int64"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -3754,7 +3754,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Test.Nested.Map", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Nested.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -3827,7 +3827,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.Nested.MapObjectNested.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Nested.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -3910,7 +3910,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.Nested.NestedList.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Nested.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -3948,7 +3948,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["str"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.Nested.Str", "obj.Str"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Nested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -4042,7 +4042,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													if c.Elems[k] != nil {
-														diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.Map", "a"})
+														diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedList.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -4115,7 +4115,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.MapObjectNested.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedList.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -4198,7 +4198,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.NestedList.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedList.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -4236,7 +4236,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
 										if tf.Attrs["str"] != nil {
-											diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.Str", "obj.Str"})
+											diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
@@ -4339,7 +4339,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
 													if c.Elems[k] != nil {
-														diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.Map", "a"})
+														diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedListNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
@@ -4412,7 +4412,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.MapObjectNested.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedListNullable.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -4495,7 +4495,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
 																if tf.Attrs["str"] != nil {
-																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.NestedList.Str", "obj.Str"})
+																	diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedListNullable.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
@@ -4533,7 +4533,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
 										if tf.Attrs["str"] != nil {
-											diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.Str", "obj.Str"})
+											diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedListNullable.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
@@ -4617,7 +4617,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.Map", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -4690,7 +4690,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.MapObjectNested.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullable.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -4773,7 +4773,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.NestedList.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullable.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -4811,7 +4811,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["str"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.Str", "obj.Str"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullable.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -4888,7 +4888,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
 											if c.Elems[k] != nil {
-												diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.Map", "a"})
+												diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullableWithNilValue.Map", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
@@ -4961,7 +4961,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.MapObjectNested.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullableWithNilValue.MapObjectNested.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -5044,7 +5044,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
 														if tf.Attrs["str"] != nil {
-															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.NestedList.Str", "obj.Str"})
+															diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullableWithNilValue.NestedList.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
@@ -5082,7 +5082,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
 								if tf.Attrs["str"] != nil {
-									diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.Str", "obj.Str"})
+									diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.NestedNullableWithNilValue.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
@@ -5113,7 +5113,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["schema_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["schema_override"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.SchemaOverride", "obj.SchemaOverride"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.SchemaOverride", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5138,7 +5138,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["str"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Str", "obj.Str"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Str", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5167,7 +5167,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["string_branch"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
 				if tf.Attrs["string_branch"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.StringBranch", "obj.StringBranch"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.StringBranch", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5215,7 +5215,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.StringList", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.StringList", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -5271,7 +5271,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.StringListEmpty", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.StringListEmpty", "github.com/hashicorp/terraform-plugin-framework/types.String"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -5313,7 +5313,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["timestamp"].(TimeValue)
 			if !ok {
 				if tf.Attrs["timestamp"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Timestamp", "obj.Timestamp"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Timestamp", "TimeValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5361,7 +5361,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
 							if c.Elems[k] != nil {
-								diags.Append(attrWriteConversionFailureDiag{"Test.TimestampList", "a"})
+								diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.TimestampList", "TimeValue"})
 							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
@@ -5399,7 +5399,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["timestamp_missing"].(TimeValue)
 			if !ok {
 				if tf.Attrs["timestamp_missing"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampMissing", "obj.TimestampMissing"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.TimestampMissing", "TimeValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5424,7 +5424,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["timestamp_nullable"].(TimeValue)
 			if !ok {
 				if tf.Attrs["timestamp_nullable"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampNullable", "obj.TimestampNullable"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.TimestampNullable", "TimeValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5454,7 +5454,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["timestamp_nullable_with_nil_value"].(TimeValue)
 			if !ok {
 				if tf.Attrs["timestamp_nullable_with_nil_value"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampNullableWithNilValue", "obj.TimestampNullableWithNilValue"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.TimestampNullableWithNilValue", "TimeValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
@@ -5484,7 +5484,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			v, ok := tf.Attrs["max_age"].(DurationValue)
 			if !ok {
 				if tf.Attrs["max_age"] != nil {
-					diags.Append(attrWriteConversionFailureDiag{"Test.Value", "obj.Value"})
+					diags.Append(attrWriteUnexpectedExistingTypeDiag{"Test.Value", "DurationValue"})
 				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2328,6 +2328,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			}
 			v, ok := tf.Attrs["bar"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["bar"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.bar", "obj.Bar"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.bar", err})
@@ -2350,6 +2353,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["bool"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 			if !ok {
+				if tf.Attrs["bool"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Bool", "obj.Bool"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Bool", err})
@@ -2411,6 +2417,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["str"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.Branch1.Str", "obj.Str"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.Branch1.Str", err})
@@ -2469,6 +2478,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["int32"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 							if !ok {
+								if tf.Attrs["int32"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.Branch2.Int32", "obj.Int32"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.Branch2.Int32", err})
@@ -2501,6 +2513,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			}
 			v, ok := tf.Attrs["branch3"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["branch3"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Branch3", "obj.Branch3"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Branch3", err})
@@ -2523,6 +2538,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["bytes"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["bytes"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.bytes", "obj.Bytes"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.bytes", err})
@@ -2568,6 +2586,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.BytesList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.BytesList", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.BytesList", err})
@@ -2598,6 +2619,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["double"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
+				if tf.Attrs["double"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Double", "obj.Double"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Double", err})
@@ -2620,6 +2644,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["duration_custom"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_custom"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustom", "obj.DurationCustom"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.DurationCustom", err})
@@ -2665,6 +2692,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.DurationCustomList {
 						v, ok := c.Elems[k].(DurationValue)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustomList", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.DurationCustomList", err})
@@ -2695,6 +2725,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["duration_custom_missing"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_custom_missing"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.DurationCustomMissing", "obj.DurationCustomMissing"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.DurationCustomMissing", err})
@@ -2717,6 +2750,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["duration_standard"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_standard"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.DurationStandard", "obj.DurationStandard"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.DurationStandard", err})
@@ -2739,6 +2775,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["duration_standard_missing"].(DurationValue)
 			if !ok {
+				if tf.Attrs["duration_standard_missing"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.DurationStandardMissing", "obj.DurationStandardMissing"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.DurationStandardMissing", err})
@@ -2787,6 +2826,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["embedded_nested_string"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["embedded_nested_string"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.EmbeddedNestedField.EmbeddedNestedString", "obj.EmbeddedNestedString"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.EmbeddedNestedField.EmbeddedNestedString", err})
@@ -2815,6 +2857,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["embedded_string"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["embedded_string"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.EmbeddedString", "obj.EmbeddedString"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.EmbeddedString", err})
@@ -2866,6 +2911,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["active"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 							if !ok {
+								if tf.Attrs["active"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.EmptyMessageBranch.active", "obj.active"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.EmptyMessageBranch.active", err})
@@ -2893,6 +2941,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["float"].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 			if !ok {
+				if tf.Attrs["float"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Float", "obj.Float"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Float", err})
@@ -2919,6 +2970,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			}
 			v, ok := tf.Attrs["foo"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["foo"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.foo", "obj.Foo"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.foo", err})
@@ -2941,6 +2995,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["int32"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["int32"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Int32", "obj.Int32"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Int32", err})
@@ -2963,6 +3020,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["int64"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["int64"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Int64", "obj.Int64"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Int64", err})
@@ -3005,6 +3065,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.Map {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.Map", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.Map", err})
@@ -3095,6 +3158,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
+													if c.Elems[k] != nil {
+														diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.Map", "a"})
+													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
 														diags.Append(attrWriteGeneralError{"Test.MapObject.Map", err})
@@ -3165,6 +3231,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.MapObjectNested.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.MapObject.MapObjectNested.Str", err})
@@ -3245,6 +3314,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.NestedList.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.MapObject.NestedList.Str", err})
@@ -3280,6 +3352,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								} else {
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
+										if tf.Attrs["str"] != nil {
+											diags.Append(attrWriteConversionFailureDiag{"Test.MapObject.Str", "obj.Str"})
+										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
 											diags.Append(attrWriteGeneralError{"Test.MapObject.Str", err})
@@ -3377,6 +3452,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
+													if c.Elems[k] != nil {
+														diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.Map", "a"})
+													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
 														diags.Append(attrWriteGeneralError{"Test.MapObjectNullable.Map", err})
@@ -3447,6 +3525,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.MapObjectNested.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.MapObjectNullable.MapObjectNested.Str", err})
@@ -3527,6 +3608,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.NestedList.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.MapObjectNullable.NestedList.Str", err})
@@ -3562,6 +3646,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								} else {
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
+										if tf.Attrs["str"] != nil {
+											diags.Append(attrWriteConversionFailureDiag{"Test.MapObjectNullable.Str", "obj.Str"})
+										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
 											diags.Append(attrWriteGeneralError{"Test.MapObjectNullable.Str", err})
@@ -3597,6 +3684,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["mode"].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 			if !ok {
+				if tf.Attrs["mode"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Mode", "obj.Mode"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Mode", err})
@@ -3663,6 +3753,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Test.Nested.Map", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Test.Nested.Map", err})
@@ -3733,6 +3826,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.Nested.MapObjectNested.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.Nested.MapObjectNested.Str", err})
@@ -3813,6 +3909,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.Nested.NestedList.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.Nested.NestedList.Str", err})
@@ -3848,6 +3947,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["str"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.Nested.Str", "obj.Str"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.Nested.Str", err})
@@ -3939,6 +4041,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
+													if c.Elems[k] != nil {
+														diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.Map", "a"})
+													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
 														diags.Append(attrWriteGeneralError{"Test.NestedList.Map", err})
@@ -4009,6 +4114,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.MapObjectNested.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.NestedList.MapObjectNested.Str", err})
@@ -4089,6 +4197,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.NestedList.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.NestedList.NestedList.Str", err})
@@ -4124,6 +4235,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								} else {
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
+										if tf.Attrs["str"] != nil {
+											diags.Append(attrWriteConversionFailureDiag{"Test.NestedList.Str", "obj.Str"})
+										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
 											diags.Append(attrWriteGeneralError{"Test.NestedList.Str", err})
@@ -4224,6 +4338,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
+													if c.Elems[k] != nil {
+														diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.Map", "a"})
+													}
 													i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 													if err != nil {
 														diags.Append(attrWriteGeneralError{"Test.NestedListNullable.Map", err})
@@ -4294,6 +4411,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.MapObjectNested.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.NestedListNullable.MapObjectNested.Str", err})
@@ -4374,6 +4494,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 														} else {
 															v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 															if !ok {
+																if tf.Attrs["str"] != nil {
+																	diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.NestedList.Str", "obj.Str"})
+																}
 																i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 																if err != nil {
 																	diags.Append(attrWriteGeneralError{"Test.NestedListNullable.NestedList.Str", err})
@@ -4409,6 +4532,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								} else {
 									v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 									if !ok {
+										if tf.Attrs["str"] != nil {
+											diags.Append(attrWriteConversionFailureDiag{"Test.NestedListNullable.Str", "obj.Str"})
+										}
 										i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 										if err != nil {
 											diags.Append(attrWriteGeneralError{"Test.NestedListNullable.Str", err})
@@ -4490,6 +4616,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.Map", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Test.NestedNullable.Map", err})
@@ -4560,6 +4689,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.MapObjectNested.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.NestedNullable.MapObjectNested.Str", err})
@@ -4640,6 +4772,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.NestedList.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.NestedNullable.NestedList.Str", err})
@@ -4675,6 +4810,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["str"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullable.Str", "obj.Str"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.NestedNullable.Str", err})
@@ -4749,6 +4887,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
+											if c.Elems[k] != nil {
+												diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.Map", "a"})
+											}
 											i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 											if err != nil {
 												diags.Append(attrWriteGeneralError{"Test.NestedNullableWithNilValue.Map", err})
@@ -4819,6 +4960,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.MapObjectNested.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.NestedNullableWithNilValue.MapObjectNested.Str", err})
@@ -4899,6 +5043,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												} else {
 													v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
+														if tf.Attrs["str"] != nil {
+															diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.NestedList.Str", "obj.Str"})
+														}
 														i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 														if err != nil {
 															diags.Append(attrWriteGeneralError{"Test.NestedNullableWithNilValue.NestedList.Str", err})
@@ -4934,6 +5081,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						} else {
 							v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 							if !ok {
+								if tf.Attrs["str"] != nil {
+									diags.Append(attrWriteConversionFailureDiag{"Test.NestedNullableWithNilValue.Str", "obj.Str"})
+								}
 								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 								if err != nil {
 									diags.Append(attrWriteGeneralError{"Test.NestedNullableWithNilValue.Str", err})
@@ -4962,6 +5112,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["schema_override"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["schema_override"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.SchemaOverride", "obj.SchemaOverride"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.SchemaOverride", err})
@@ -4984,6 +5137,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["str"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["str"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Str", "obj.Str"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Str", err})
@@ -5010,6 +5166,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 			}
 			v, ok := tf.Attrs["string_branch"].(github_com_hashicorp_terraform_plugin_framework_types.String)
 			if !ok {
+				if tf.Attrs["string_branch"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.StringBranch", "obj.StringBranch"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.StringBranch", err})
@@ -5055,6 +5214,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.StringList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.StringList", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.StringList", err})
@@ -5108,6 +5270,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.StringListEmpty {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.StringListEmpty", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.StringListEmpty", err})
@@ -5147,6 +5312,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["timestamp"].(TimeValue)
 			if !ok {
+				if tf.Attrs["timestamp"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Timestamp", "obj.Timestamp"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Timestamp", err})
@@ -5192,6 +5360,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					for k, a := range obj.TimestampList {
 						v, ok := c.Elems[k].(TimeValue)
 						if !ok {
+							if c.Elems[k] != nil {
+								diags.Append(attrWriteConversionFailureDiag{"Test.TimestampList", "a"})
+							}
 							i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 							if err != nil {
 								diags.Append(attrWriteGeneralError{"Test.TimestampList", err})
@@ -5227,6 +5398,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["timestamp_missing"].(TimeValue)
 			if !ok {
+				if tf.Attrs["timestamp_missing"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampMissing", "obj.TimestampMissing"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.TimestampMissing", err})
@@ -5249,6 +5423,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["timestamp_nullable"].(TimeValue)
 			if !ok {
+				if tf.Attrs["timestamp_nullable"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampNullable", "obj.TimestampNullable"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.TimestampNullable", err})
@@ -5276,6 +5453,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["timestamp_nullable_with_nil_value"].(TimeValue)
 			if !ok {
+				if tf.Attrs["timestamp_nullable_with_nil_value"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.TimestampNullableWithNilValue", "obj.TimestampNullableWithNilValue"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.TimestampNullableWithNilValue", err})
@@ -5303,6 +5483,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 		} else {
 			v, ok := tf.Attrs["max_age"].(DurationValue)
 			if !ok {
+				if tf.Attrs["max_age"] != nil {
+					diags.Append(attrWriteConversionFailureDiag{"Test.Value", "obj.Value"})
+				}
 				i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
 				if err != nil {
 					diags.Append(attrWriteGeneralError{"Test.Value", err})
@@ -5430,5 +5613,28 @@ func (d attrWriteGeneralError) Detail() string {
 }
 
 func (d attrWriteGeneralError) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
+	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
+}
+
+// attrWriteUnexpectedExistingTypeDiag represents diagnostic message when a field is initialized with a value whose go
+// type does not match what we'd expect.
+type attrWriteUnexpectedExistingTypeDiag struct {
+	Path string
+	Type string
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Severity() github_com_hashicorp_terraform_plugin_framework_diag.Severity {
+	return github_com_hashicorp_terraform_plugin_framework_diag.SeverityError
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Summary() string {
+	return "Error writing to Terraform object"
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Detail() string {
+	return fmt.Sprintf("A value for %v is already initialized and its type is not %v", d.Path, d.Type)
+}
+
+func (d attrWriteUnexpectedExistingTypeDiag) Equal(o github_com_hashicorp_terraform_plugin_framework_diag.Diagnostic) bool {
 	return (d.Severity() == o.Severity()) && (d.Summary() == o.Summary()) && (d.Detail() == o.Detail())
 }


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397
Closes https://github.com/gravitational/protoc-gen-terraform/issues/58

This PR fixes the conversion logic for list and map type attributes, and allows zero value list elements.

Below is an example of the bool list conversion code, simplified to show the core logic:

```go
c := tf.Attrs["bool_list"].(github_com_hashicorp_terraform_plugin_framework_types.List)
if obj.BoolList != nil {
	for k, a := range obj.BoolList {

		// Before this change, the function attempted to access the list or map
		// attribute as though it were accessing an element of the attribute.
		// Therefore, the type assertion would always fail.
		- v, ok := tf.Attrs["bool_list"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)

		// After this change, the function uses the "k" index or key to access the
		// list or map attribute element correctly.
		+ v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
		
		if !ok {
			v.Null = bool(a) == false
		}
		c.Elems[k] = v
	}
}
tf.Attrs["bool_list"] = c
```

### What this change means for the TF provider and users

List elements can now support zero values. This should not be a breaking change. Previously, whether an attribute was computed or non-computed, if a user provided a zero value element, the TF provider would have reported an inconsistent state after apply.

Note that although both list and map types contained this bug in the conversion logic, map types still supported zero values. This is because amp attribute values always evaluated to a non-null value.