### PR TITLE
Allow Copy*ToTerraform with nil slice/map

### DIFF
--- a/examples/testlib/computed_test.go
+++ b/examples/testlib/computed_test.go
@@ -138,17 +138,13 @@ func testCheckComputedResourceZeroValue(name string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(name, "nested_value.leaf.value", ""),
 		resource.TestCheckNoResourceAttr(name, "nested_nullable.leaf.value"),
 
-		// TODO: Updates with computed list and map type attributes result in
-		// unexpected behavior. Previous state is not overridden. This will be
-		// fixed in a follow up PR.
-
-		// resource.TestCheckResourceAttr(name, "computed_list.string_list.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_list.int64_list.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_list.float_list.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_list.bool_list.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_map.string_map.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_map.int64_map.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_map.float_map.#", "0"),
-		// resource.TestCheckResourceAttr(name, "computed_map.bool_map.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_list.string_list.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_list.int64_list.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_list.float_list.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_list.bool_list.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_map.string_map.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_map.int64_map.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_map.float_map.#", "0"),
+		resource.TestCheckResourceAttr(name, "computed_map.bool_map.#", "0"),
 	)
 }

--- a/examples/tfschema/computed/v1/computed_terraform.go
+++ b/examples/tfschema/computed/v1/computed_terraform.go
@@ -1374,7 +1374,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 								}
-								if obj.BoolList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -1427,7 +1427,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 								}
-								if obj.FloatList != nil {
+								{
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -1480,7 +1480,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 								}
-								if obj.Int64List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -1533,7 +1533,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 								}
-								if obj.StringList != nil {
+								{
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -1616,7 +1616,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
 									}
 								}
-								if obj.BoolMap != nil {
+								{
 									t := o.ElemType
 									if len(obj.BoolMap) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
@@ -1669,7 +1669,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatMap))
 									}
 								}
-								if obj.FloatMap != nil {
+								{
 									t := o.ElemType
 									if len(obj.FloatMap) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatMap))
@@ -1722,7 +1722,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64Map))
 									}
 								}
-								if obj.Int64Map != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int64Map) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64Map))
@@ -1775,7 +1775,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
 									}
 								}
-								if obj.StringMap != nil {
+								{
 									t := o.ElemType
 									if len(obj.StringMap) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
@@ -2178,7 +2178,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 								}
-								if obj.BoolList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -2253,7 +2253,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 									}
 								}
-								if obj.BytesList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BytesList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2328,7 +2328,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 									}
 								}
-								if obj.DoubleList != nil {
+								{
 									t := o.ElemType
 									if len(obj.DoubleList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -2403,7 +2403,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 									}
 								}
-								if obj.EnumList != nil {
+								{
 									t := o.ElemType
 									if len(obj.EnumList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -2478,7 +2478,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 								}
-								if obj.FloatList != nil {
+								{
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -2575,7 +2575,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 									}
 								}
-								if obj.Int32List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int32List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -2650,7 +2650,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 								}
-								if obj.Int64List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -2725,7 +2725,7 @@ func CopyComputedToTerraform(ctx context.Context, obj *github_com_gravitational_
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 								}
-								if obj.StringList != nil {
+								{
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1307,7 +1307,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
 					}
 				}
-				if obj.BoolMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.BoolMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
@@ -1607,7 +1607,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.IntMap))
 					}
 				}
-				if obj.IntMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.IntMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -1709,7 +1709,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -1817,7 +1817,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedMap))
 					}
 				}
-				if obj.NestedMap != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2006,7 +2006,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
 					}
 				}
-				if obj.NestedNullableList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedNullableList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
@@ -2116,7 +2116,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableMap))
 					}
 				}
-				if obj.NestedNullableMap != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedNullableMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2329,7 +2329,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 								}
-								if obj.BoolList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -2404,7 +2404,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 									}
 								}
-								if obj.BytesList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BytesList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2479,7 +2479,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 									}
 								}
-								if obj.DoubleList != nil {
+								{
 									t := o.ElemType
 									if len(obj.DoubleList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -2554,7 +2554,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 									}
 								}
-								if obj.EnumList != nil {
+								{
 									t := o.ElemType
 									if len(obj.EnumList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -2629,7 +2629,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 								}
-								if obj.FloatList != nil {
+								{
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -2726,7 +2726,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 									}
 								}
-								if obj.Int32List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int32List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -2801,7 +2801,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 								}
-								if obj.Int64List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -2876,7 +2876,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 								}
-								if obj.StringList != nil {
+								{
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -2957,7 +2957,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
 					}
 				}
-				if obj.StringMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.StringMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -536,7 +536,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 					}
 				}
-				if obj.BoolList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BoolList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -611,7 +611,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -686,7 +686,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 					}
 				}
-				if obj.DoubleList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DoubleList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -761,7 +761,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 					}
 				}
-				if obj.EnumList != nil {
+				{
 					t := o.ElemType
 					if len(obj.EnumList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -836,7 +836,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 					}
 				}
-				if obj.FloatList != nil {
+				{
 					t := o.ElemType
 					if len(obj.FloatList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -933,7 +933,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 					}
 				}
-				if obj.Int32List != nil {
+				{
 					t := o.ElemType
 					if len(obj.Int32List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -1008,7 +1008,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 					}
 				}
-				if obj.Int64List != nil {
+				{
 					t := o.ElemType
 					if len(obj.Int64List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -1083,7 +1083,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -292,7 +292,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -345,7 +345,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
 					}
 				}
-				if obj.DurationList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
@@ -442,7 +442,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -324,7 +324,7 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 				),
 			)
 
-			g.If(j.Id(fieldName)).Op("!=").Nil().BlockFunc(func(g *j.Group) {
+			g.BlockFunc(func(g *j.Group) {
 				if (f.Kind == PrimitiveListKind) || (f.Kind == PrimitiveMapKind) {
 					g.Id("t").Op(":=").Id("o.ElemType")
 				} else {

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2560,7 +2560,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2657,7 +2657,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -3000,7 +3000,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 					}
 				}
-				if obj.Map != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.Map {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3050,7 +3050,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObject))
 					}
 				}
-				if obj.MapObject != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObject {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3090,7 +3090,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3140,7 +3140,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3215,7 +3215,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3330,7 +3330,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNullable))
 					}
 				}
-				if obj.MapObjectNullable != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObjectNullable {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3372,7 +3372,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3422,7 +3422,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3497,7 +3497,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3658,7 +3658,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3708,7 +3708,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3783,7 +3783,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3891,7 +3891,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3934,7 +3934,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3984,7 +3984,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4059,7 +4059,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4174,7 +4174,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
 					}
 				}
-				if obj.NestedListNullable != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedListNullable) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
@@ -4219,7 +4219,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4269,7 +4269,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4344,7 +4344,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4485,7 +4485,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4535,7 +4535,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4610,7 +4610,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4744,7 +4744,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4794,7 +4794,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4869,7 +4869,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -5047,7 +5047,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -5100,7 +5100,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
 					}
 				}
-				if obj.StringListEmpty != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringListEmpty) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
@@ -5184,7 +5184,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397
Supports https://github.com/gravitational/teleport/issues/59339

This change allows nil slices/maps to be copied to Terraform state. This does not mean the resulting Terraform state will contain `null` list/maps, instead they will be empty lists/maps.