### PR TITLE
Fix Bool zero value cause false to be null

### DIFF
--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -2424,7 +2424,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 											if !ok {
 												diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 											}
-											v.Null = bool(a) == false
+											v.Null = false
 										}
 										v.Value = bool(a)
 										v.Unknown = false
@@ -2454,7 +2454,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 								if !ok {
 									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.bool_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
-								v.Null = bool(obj.BoolValue) == false
+								v.Null = false
 							}
 							v.Value = bool(obj.BoolValue)
 							v.Unknown = false
@@ -2948,7 +2948,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 								if !ok {
 									diags.Append(attrWriteConversionFailureDiag{"Objects.primitives.nullable_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 								}
-								v.Null = bool(obj.NullableValue) == false
+								v.Null = false
 							}
 							v.Value = bool(obj.NullableValue)
 							v.Unknown = false

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -574,7 +574,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 							if !ok {
 								diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 							}
-							v.Null = bool(a) == false
+							v.Null = false
 						}
 						v.Value = bool(a)
 						v.Unknown = false
@@ -604,7 +604,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"Primitives.bool_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
-				v.Null = bool(obj.BoolValue) == false
+				v.Null = false
 			}
 			v.Value = bool(obj.BoolValue)
 			v.Unknown = false
@@ -1098,7 +1098,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"Primitives.nullable_value", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
-				v.Null = bool(obj.NullableValue) == false
+				v.Null = false
 			}
 			v.Value = bool(obj.NullableValue)
 			v.Unknown = false

--- a/field_build_context.go
+++ b/field_build_context.go
@@ -67,7 +67,7 @@ var (
 		ElemType:         Types + ".BoolType",
 		ElemValueType:    Types + ".Bool",
 		ValueCastToType:  "bool",
-		ZeroValue:        "false",
+		ZeroValue:        "",
 		IsTypeScalar:     true,
 		IsElemTypeScalar: true,
 	}

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -61,6 +61,18 @@ func TestCopyToTerraformPrimitives(t *testing.T) {
 	require.False(t, o.Attrs["bytes"].(types.String).Null)
 }
 
+func TestCopyToBoolZeroValue(t *testing.T) {
+	o := copyToTerraformObject(t)
+	obj := createTestObj()
+	obj.Bool = false
+	diags := CopyTestToTerraform(t.Context(), obj, &o)
+	requireNoDiagErrors(t, diags)
+
+	require.Equal(t, false, o.Attrs["bool"].(types.Bool).Value)
+	require.False(t, o.Attrs["bool"].(types.Bool).Unknown)
+	require.False(t, o.Attrs["bool"].(types.Bool).Null)
+}
+
 func TestCopyToTime(t *testing.T) {
 	o := copyToTerraformObject(t)
 

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2358,7 +2358,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				if !ok {
 					diags.Append(attrWriteConversionFailureDiag{"Test.Bool", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
 				}
-				v.Null = bool(obj.Bool) == false
+				v.Null = false
 			}
 			v.Value = bool(obj.Bool)
 			v.Unknown = false


### PR DESCRIPTION
Running into an issue in Teleport terraform module where a bool value can't complete a round-trip from the terraform module to the server and back. When a bool value is set to false, it's getting deserialized as null, which causes a terraform error.

For bools, this package is treating `false` as a zero / absent value and marking it as null. Bool has no zero value, so we should skip that initialization logic and always consider it present.