### PR TITLE
Add request dump and debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,25 @@ Current version number resides in the VERSION file. To update the file contents 
 git tag v1.1.1
 go generate
 ```
+
+# Debugging
+
+The plugin can be configured to dump the `protoc` generation request by setting the `PROTOC_GEN_TERRAFORM_DUMP` env var.
+The dumped request can then be replayed by sending it to the plugin's stdin.
+For example:
+
+```
+export PROTOC_GEN_TERRAFORM_DUMP="$(mktemp)"
+echo "$PROTOC_GEN_TERRAFORM_DUMP"
+
+# note that make gen calls the plugin several times, only the last request is logged, which is usually the one that fails.
+make gen
+
+# invoke the plugin again, but replay the saved request
+./build/protoc-gen-terraform < "$PROTOC_GEN_TERRAFORM_DUMP"
+```
+
+Debuggers can be configured to read stdin from the file:
+* in GoLand: on a `Go Build` target, set `Redirect input from` to the dump file path
+* in VSCode: in the `Launch.json` file, set `stdinFrom` to the dump file path
+* with `dlv`: `dlv exec ./build/protoc-gen-terraform --listen=:2345 --headless=true --api-version=2 --accept-multiclient --redirect stdin:"$PROTOC_GEN_TERRAFORM_DUMP"

--- a/main.go
+++ b/main.go
@@ -17,10 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"io"
 	"os"
 	"regexp"
 	"strings"
 
+	gogoproto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
 	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity/command"
 	"github.com/gravitational/trace"
@@ -49,7 +52,7 @@ func main() {
 
 	p := NewPlugin()
 
-	req := command.Read()
+	req := Read()
 	resp := command.GeneratePlugin(req, p, "_terraform.go")
 
 	err := runGoImports(p, resp)
@@ -134,4 +137,32 @@ func replacePackageName(s string, target string) string {
 	}
 
 	return strings.Replace(s, pkg, "package "+target+"\n", 1)
+}
+
+// Read is command.Read but it supports dumping the protoc request in a file for debugging purposes.
+func Read() *plugin_go.CodeGeneratorRequest {
+	g := generator.New()
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		g.Error(err, "reading input")
+	}
+
+	// Dump the request in a file if configured.
+	// This file can then be used to replay the request with a debugger attached.
+	// Once the request is dumped, run `protoc-gen-tfschema < "$PROTOC_GEN_TERRAFORM_DUMP"` to
+	// replay it.
+	if dumpPath := os.Getenv("PROTOC_GEN_TERRAFORM_DUMP"); dumpPath != "" {
+		if err := os.WriteFile(dumpPath, data, 0644); err != nil {
+			g.Error(err, "writing dump file: ", dumpPath)
+		}
+	}
+
+	if err := gogoproto.Unmarshal(data, g.Request); err != nil {
+		g.Error(err, "parsing input proto")
+	}
+
+	if len(g.Request.FileToGenerate) == 0 {
+		g.Fail("no files to generate")
+	}
+	return g.Request
 }


### PR DESCRIPTION
When testing https://github.com/gravitational/protoc-gen-terraform/pull/60 I wanted to see how a real request was processed (both form the integration tests in `example/testlib` and from the real Teleport repo).

This PR adds an environment variable `PROTOC_GEN_TERRAFORM_DUMP` that can be used to dump the `protoc` request for future replay, with a debugger attached.

I'll write more debugging details in the wiki, covering also how to debug the provider itself.