### PR TITLE
Corretly set `Null` field for list/map attributes

### DIFF
--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -404,8 +404,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.bool_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.BoolMap = make(map[string]bool, len(v.Elems))
+				obj.BoolMap = nil
 				if !v.Null && !v.Unknown {
+					obj.BoolMap = make(map[string]bool, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
@@ -645,8 +646,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.int_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.IntMap = make(map[string]int64, len(v.Elems))
+				obj.IntMap = nil
 				if !v.Null && !v.Unknown {
+					obj.IntMap = make(map[string]int64, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
@@ -706,8 +708,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.nested_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.NestedList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
+				obj.NestedList = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -768,8 +771,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.nested_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.NestedMap = make(map[string]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
+				obj.NestedMap = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedMap = make(map[string]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -882,8 +886,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.nested_nullable_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.NestedNullableList = make([]*github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
+				obj.NestedNullableList = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedNullableList = make([]*github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -945,8 +950,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.nested_nullable_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.NestedNullableMap = make(map[string]*github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
+				obj.NestedNullableMap = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedNullableMap = make(map[string]*github_com_gravitational_protoc_gen_terraform_v3_examples_types.Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -1072,8 +1078,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.BoolList = make([]bool, len(v.Elems))
+								obj.BoolList = nil
 								if !v.Null && !v.Unknown {
+									obj.BoolList = make([]bool, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 										if !ok {
@@ -1116,8 +1123,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.bytes_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.BytesList = make([][]byte, len(v.Elems))
+								obj.BytesList = nil
 								if !v.Null && !v.Unknown {
+									obj.BytesList = make([][]byte, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -1160,8 +1168,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.double_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.DoubleList = make([]float64, len(v.Elems))
+								obj.DoubleList = nil
 								if !v.Null && !v.Unknown {
+									obj.DoubleList = make([]float64, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
@@ -1204,8 +1213,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.enum_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.EnumList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.EnumValue, len(v.Elems))
+								obj.EnumList = nil
 								if !v.Null && !v.Unknown {
+									obj.EnumList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.EnumValue, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
@@ -1248,8 +1258,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.float_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.FloatList = make([]float32, len(v.Elems))
+								obj.FloatList = nil
 								if !v.Null && !v.Unknown {
+									obj.FloatList = make([]float32, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 										if !ok {
@@ -1309,8 +1320,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.int32_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.Int32List = make([]int32, len(v.Elems))
+								obj.Int32List = nil
 								if !v.Null && !v.Unknown {
+									obj.Int32List = make([]int32, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
@@ -1353,8 +1365,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.int64_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.Int64List = make([]int64, len(v.Elems))
+								obj.Int64List = nil
 								if !v.Null && !v.Unknown {
+									obj.Int64List = make([]int64, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 										if !ok {
@@ -1397,8 +1410,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Objects.primitives.string_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.StringList = make([]string, len(v.Elems))
+								obj.StringList = nil
 								if !v.Null && !v.Unknown {
+									obj.StringList = make([]string, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -1445,8 +1459,9 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Objects.string_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.StringMap = make(map[string]string, len(v.Elems))
+				obj.StringMap = nil
 				if !v.Null && !v.Unknown {
+					obj.StringMap = make(map[string]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -1496,7 +1511,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
 					}
 				}
-				if obj.BoolMap != nil {
+				if obj.BoolMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					for k, a := range obj.BoolMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
@@ -1518,9 +1536,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Value = bool(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.BoolMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -1974,7 +1989,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.IntMap))
 					}
 				}
-				if obj.IntMap != nil {
+				if obj.IntMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					for k, a := range obj.IntMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -1996,9 +2014,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Value = int64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.IntMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -2085,7 +2100,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				if obj.NestedList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -2168,9 +2186,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedList) > 0 {
-						c.Null = false
-					}
 				}
 				c.Unknown = false
 				tf.Attrs["nested_list"] = c
@@ -2199,7 +2214,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedMap))
 					}
 				}
-				if obj.NestedMap != nil {
+				if obj.NestedMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2278,9 +2296,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						}
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.NestedMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -2400,7 +2415,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
 					}
 				}
-				if obj.NestedNullableList != nil {
+				if obj.NestedNullableList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedNullableList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
@@ -2485,9 +2503,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedNullableList) > 0 {
-						c.Null = false
-					}
 				}
 				c.Unknown = false
 				tf.Attrs["nested_nullable_list"] = c
@@ -2516,7 +2531,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableMap))
 					}
 				}
-				if obj.NestedNullableMap != nil {
+				if obj.NestedNullableMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedNullableMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2597,9 +2615,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						}
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.NestedNullableMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -2742,7 +2757,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 								}
-								if obj.BoolList != nil {
+								if obj.BoolList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -2767,9 +2785,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = bool(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.BoolList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -2825,7 +2840,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 									}
 								}
-								if obj.BytesList != nil {
+								if obj.BytesList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.BytesList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2850,9 +2868,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = string(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.BytesList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -2908,7 +2923,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 									}
 								}
-								if obj.DoubleList != nil {
+								if obj.DoubleList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.DoubleList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -2933,9 +2951,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = float64(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.DoubleList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -2991,7 +3006,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 									}
 								}
-								if obj.EnumList != nil {
+								if obj.EnumList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.EnumList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -3016,9 +3034,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = int64(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.EnumList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3074,7 +3089,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 								}
-								if obj.FloatList != nil {
+								if obj.FloatList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -3099,9 +3117,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = float64(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.FloatList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3183,7 +3198,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 									}
 								}
-								if obj.Int32List != nil {
+								if obj.Int32List == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.Int32List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -3208,9 +3226,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = int64(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.Int32List) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3266,7 +3281,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 								}
-								if obj.Int64List != nil {
+								if obj.Int64List == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -3291,9 +3309,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = int64(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.Int64List) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3349,7 +3364,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 								}
-								if obj.StringList != nil {
+								if obj.StringList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -3374,9 +3392,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Value = string(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.StringList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3438,7 +3453,10 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
 					}
 				}
-				if obj.StringMap != nil {
+				if obj.StringMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					for k, a := range obj.StringMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3460,9 +3478,6 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.StringMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -175,8 +175,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.bool_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.BoolList = make([]bool, len(v.Elems))
+				obj.BoolList = nil
 				if !v.Null && !v.Unknown {
+					obj.BoolList = make([]bool, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
@@ -219,8 +220,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.bytes_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.BytesList = make([][]byte, len(v.Elems))
+				obj.BytesList = nil
 				if !v.Null && !v.Unknown {
+					obj.BytesList = make([][]byte, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -263,8 +265,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.double_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.DoubleList = make([]float64, len(v.Elems))
+				obj.DoubleList = nil
 				if !v.Null && !v.Unknown {
+					obj.DoubleList = make([]float64, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
@@ -307,8 +310,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.enum_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.EnumList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.EnumValue, len(v.Elems))
+				obj.EnumList = nil
 				if !v.Null && !v.Unknown {
+					obj.EnumList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.EnumValue, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
@@ -351,8 +355,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.float_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.FloatList = make([]float32, len(v.Elems))
+				obj.FloatList = nil
 				if !v.Null && !v.Unknown {
+					obj.FloatList = make([]float32, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Float64)
 						if !ok {
@@ -412,8 +417,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.int32_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.Int32List = make([]int32, len(v.Elems))
+				obj.Int32List = nil
 				if !v.Null && !v.Unknown {
+					obj.Int32List = make([]int32, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
@@ -456,8 +462,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.int64_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.Int64List = make([]int64, len(v.Elems))
+				obj.Int64List = nil
 				if !v.Null && !v.Unknown {
+					obj.Int64List = make([]int64, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
@@ -500,8 +507,9 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Primitives.string_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.StringList = make([]string, len(v.Elems))
+				obj.StringList = nil
 				if !v.Null && !v.Unknown {
+					obj.StringList = make([]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -568,7 +576,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 					}
 				}
-				if obj.BoolList != nil {
+				if obj.BoolList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.BoolList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -593,9 +604,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = bool(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.BoolList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -651,7 +659,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				if obj.BytesList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -676,9 +687,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.BytesList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -734,7 +742,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 					}
 				}
-				if obj.DoubleList != nil {
+				if obj.DoubleList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.DoubleList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -759,9 +770,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = float64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.DoubleList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -817,7 +825,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 					}
 				}
-				if obj.EnumList != nil {
+				if obj.EnumList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.EnumList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -842,9 +853,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = int64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.EnumList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -900,7 +908,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 					}
 				}
-				if obj.FloatList != nil {
+				if obj.FloatList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.FloatList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -925,9 +936,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = float64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.FloatList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -1009,7 +1017,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 					}
 				}
-				if obj.Int32List != nil {
+				if obj.Int32List == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.Int32List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -1034,9 +1045,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = int64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.Int32List) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -1092,7 +1100,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 					}
 				}
-				if obj.Int64List != nil {
+				if obj.Int64List == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.Int64List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -1117,9 +1128,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = int64(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.Int64List) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -1175,7 +1183,10 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				if obj.StringList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -1200,9 +1211,6 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -136,8 +136,9 @@ func CopyTimeFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Time.duration_custom_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.DurationCustomList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Duration, len(v.Elems))
+				obj.DurationCustomList = nil
 				if !v.Null && !v.Unknown {
+					obj.DurationCustomList = make([]github_com_gravitational_protoc_gen_terraform_v3_examples_types.Duration, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(DurationValue)
 						if !ok {
@@ -163,8 +164,9 @@ func CopyTimeFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Time.duration_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.DurationList = make([]time.Duration, len(v.Elems))
+				obj.DurationList = nil
 				if !v.Null && !v.Unknown {
+					obj.DurationList = make([]time.Duration, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(DurationValue)
 						if !ok {
@@ -260,8 +262,9 @@ func CopyTimeFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Time.timestamp_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.TimestampList = make([]time.Time, len(v.Elems))
+				obj.TimestampList = nil
 				if !v.Null && !v.Unknown {
+					obj.TimestampList = make([]time.Time, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(TimeValue)
 						if !ok {
@@ -354,7 +357,10 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				if obj.DurationCustomList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -379,9 +385,6 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Value = time.Duration(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.DurationCustomList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -411,7 +414,10 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
 					}
 				}
-				if obj.DurationList != nil {
+				if obj.DurationList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.DurationList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
@@ -436,9 +442,6 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Value = time.Duration(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.DurationList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -578,7 +581,10 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				if obj.TimestampList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
@@ -603,9 +609,6 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Value = time.Time(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.TimestampList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false

--- a/gen_copy_from.go
+++ b/gen_copy_from.go
@@ -135,11 +135,13 @@ func (f *FieldCopyFromGenerator) genPrimitiveBody(g *j.Group) {
 func (f *FieldCopyFromGenerator) genListOrMapIterator(g *j.Group, typ *j.Statement, els func(g *j.Group)) {
 	objFieldName := "obj." + f.Name
 
-	// obj.List = make([]string, len(v.Elems)) - same for maps
-	g.Id(objFieldName).Op("=").Make(j.Id(f.i.WithType(f.GoType)), j.Len(j.Id("v.Elems")))
+	g.Id(objFieldName).Op("=").Nil()
 
 	// if !v.Null
 	g.If(j.Id("!v.Null && !v.Unknown")).BlockFunc(func(g *j.Group) {
+		// obj.List = make([]string, len(v.Elems)) - same for maps
+		g.Id(objFieldName).Op("=").Make(j.Id(f.i.WithType(f.GoType)), j.Len(j.Id("v.Elems")))
+
 		// for k, el := range v.Elems - where k is either index or map key
 		g.For(j.List(j.Id("k"), j.Id("a"))).Op(":=").Range().Id("v.Elems").BlockFunc(func(g *j.Group) {
 			// v, ok := a.(types.String)

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -405,7 +405,11 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 				),
 			)
 
-			g.If(j.Id(fieldName)).Op("!=").Nil().BlockFunc(func(g *j.Group) {
+			g.If(j.Id(fieldName)).Op("==").Nil().Block(
+				j.Id("c.Null").Op("=").True(),
+			).Else().BlockFunc(func(g *j.Group) {
+				g.Id("c.Null").Op("=").False()
+
 				if (f.Kind == PrimitiveListKind) || (f.Kind == PrimitiveMapKind) {
 					g.Id("t").Op(":=").Id("o.ElemType")
 				} else {
@@ -436,11 +440,6 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 					}
 					g.Id("c.Elems").Index(j.Id("k")).Op("=").Id("v")
 				})
-
-				// if len(obj.Test) > 0
-				g.If(j.Len(j.Id(fieldName))).Op(">").Lit(0).Block(
-					j.Id("c.Null").Op("=").False(),
-				)
 			})
 
 			g.Id("c.Unknown").Op("=").False()

--- a/test/copy_from_terraform_test.go
+++ b/test/copy_from_terraform_test.go
@@ -100,6 +100,19 @@ func TestCopyFromList(t *testing.T) {
 	require.Equal(t, []Duration{Duration(duration), Duration(duration)}, target.DurationCustomList)
 }
 
+func TestCopyFromNullList(t *testing.T) {
+	obj := copyFromTerraformObject(t)
+	obj.Attrs["string_list_empty"] = types.List{
+		Null: true,
+	}
+
+	target := Test{}
+	diags := CopyTestFromTerraform(context.Background(), obj, &target)
+	requireNoDiagErrors(t, diags)
+
+	require.Nil(t, target.StringListEmpty)
+}
+
 func TestCopyFromNestedList(t *testing.T) {
 	obj := copyFromTerraformObject(t)
 

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -147,6 +147,23 @@ func TestCopyToList(t *testing.T) {
 	}, o.Attrs["duration_custom_list"].(types.List).Elems)
 }
 
+func TestCopyToEmptyList(t *testing.T) {
+	o := copyToTerraformObject(t)
+
+	testObj := createTestObj()
+	testObj.StringListEmpty = []string{}
+
+	diags := CopyTestToTerraform(context.Background(), testObj, &o)
+	requireNoDiagErrors(t, diags)
+
+	require.Equal(t, types.List{
+		Null:     false,
+		Unknown:  false,
+		Elems:    make([]attr.Value, 0),
+		ElemType: types.StringType,
+	}, o.Attrs["string_list_empty"].(types.List))
+}
+
 func TestCopyTo_ChangeListSize(t *testing.T) {
 	o := copyToTerraformObject(t)
 

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -212,8 +212,9 @@ func CopyOptionalTestFromTerraform(_ context.Context, tf github_com_hashicorp_te
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"OptionalTest.optional_map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.OptionalMap = make(map[string]string, len(v.Elems))
+				obj.OptionalMap = nil
 				if !v.Null && !v.Unknown {
+					obj.OptionalMap = make(map[string]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -257,8 +258,9 @@ func CopyOptionalTestFromTerraform(_ context.Context, tf github_com_hashicorp_te
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"OptionalTest.string_list", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.StringList = make([]string, len(v.Elems))
+				obj.StringList = nil
 				if !v.Null && !v.Unknown {
+					obj.StringList = make([]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -492,7 +494,10 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.OptionalMap))
 					}
 				}
-				if obj.OptionalMap != nil {
+				if obj.OptionalMap == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					for k, a := range obj.OptionalMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -514,9 +519,6 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.OptionalMap) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -575,7 +577,10 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				if obj.StringList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -600,9 +605,6 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -773,8 +773,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.BytesList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.BytesList = make([][]byte, len(v.Elems))
+				obj.BytesList = nil
 				if !v.Null && !v.Unknown {
+					obj.BytesList = make([][]byte, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -834,8 +835,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.DurationCustomList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.DurationCustomList = make([]Duration, len(v.Elems))
+				obj.DurationCustomList = nil
 				if !v.Null && !v.Unknown {
+					obj.DurationCustomList = make([]Duration, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(DurationValue)
 						if !ok {
@@ -1050,8 +1052,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.Map = make(map[string]string, len(v.Elems))
+				obj.Map = nil
 				if !v.Null && !v.Unknown {
+					obj.Map = make(map[string]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -1077,8 +1080,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.MapObject", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.MapObject = make(map[string]Nested, len(v.Elems))
+				obj.MapObject = nil
 				if !v.Null && !v.Unknown {
+					obj.MapObject = make(map[string]Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -1097,8 +1101,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObject.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.Map = make(map[string]string, len(v.Elems))
+											obj.Map = nil
 											if !v.Null && !v.Unknown {
+												obj.Map = make(map[string]string, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
@@ -1124,8 +1129,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObject.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+											obj.MapObjectNested = nil
 											if !v.Null && !v.Unknown {
+												obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1169,8 +1175,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObject.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 										} else {
-											obj.NestedList = make([]*OtherNested, len(v.Elems))
+											obj.NestedList = nil
 											if !v.Null && !v.Unknown {
+												obj.NestedList = make([]*OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1240,8 +1247,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.MapObjectNullable", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 			} else {
-				obj.MapObjectNullable = make(map[string]*Nested, len(v.Elems))
+				obj.MapObjectNullable = nil
 				if !v.Null && !v.Unknown {
+					obj.MapObjectNullable = make(map[string]*Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -1261,8 +1269,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObjectNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.Map = make(map[string]string, len(v.Elems))
+											obj.Map = nil
 											if !v.Null && !v.Unknown {
+												obj.Map = make(map[string]string, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
@@ -1288,8 +1297,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObjectNullable.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+											obj.MapObjectNested = nil
 											if !v.Null && !v.Unknown {
+												obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1333,8 +1343,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.MapObjectNullable.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 										} else {
-											obj.NestedList = make([]*OtherNested, len(v.Elems))
+											obj.NestedList = nil
 											if !v.Null && !v.Unknown {
+												obj.NestedList = make([]*OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1434,8 +1445,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.Nested.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.Map = make(map[string]string, len(v.Elems))
+								obj.Map = nil
 								if !v.Null && !v.Unknown {
+									obj.Map = make(map[string]string, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -1461,8 +1473,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.Nested.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+								obj.MapObjectNested = nil
 								if !v.Null && !v.Unknown {
+									obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -1506,8 +1519,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.Nested.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.NestedList = make([]*OtherNested, len(v.Elems))
+								obj.NestedList = nil
 								if !v.Null && !v.Unknown {
+									obj.NestedList = make([]*OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -1573,8 +1587,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.NestedList = make([]Nested, len(v.Elems))
+				obj.NestedList = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedList = make([]Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -1593,8 +1608,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedList.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.Map = make(map[string]string, len(v.Elems))
+											obj.Map = nil
 											if !v.Null && !v.Unknown {
+												obj.Map = make(map[string]string, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
@@ -1620,8 +1636,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedList.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+											obj.MapObjectNested = nil
 											if !v.Null && !v.Unknown {
+												obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1665,8 +1682,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedList.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 										} else {
-											obj.NestedList = make([]*OtherNested, len(v.Elems))
+											obj.NestedList = nil
 											if !v.Null && !v.Unknown {
+												obj.NestedList = make([]*OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1736,8 +1754,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.NestedListNullable", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.NestedListNullable = make([]*Nested, len(v.Elems))
+				obj.NestedListNullable = nil
 				if !v.Null && !v.Unknown {
+					obj.NestedListNullable = make([]*Nested, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -1757,8 +1776,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedListNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.Map = make(map[string]string, len(v.Elems))
+											obj.Map = nil
 											if !v.Null && !v.Unknown {
+												obj.Map = make(map[string]string, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 													if !ok {
@@ -1784,8 +1804,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedListNullable.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 										} else {
-											obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+											obj.MapObjectNested = nil
 											if !v.Null && !v.Unknown {
+												obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1829,8 +1850,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 										if !ok {
 											diags.Append(attrReadConversionFailureDiag{"Test.NestedListNullable.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 										} else {
-											obj.NestedList = make([]*OtherNested, len(v.Elems))
+											obj.NestedList = nil
 											if !v.Null && !v.Unknown {
+												obj.NestedList = make([]*OtherNested, len(v.Elems))
 												for k, a := range v.Elems {
 													v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 													if !ok {
@@ -1914,8 +1936,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullable.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.Map = make(map[string]string, len(v.Elems))
+								obj.Map = nil
 								if !v.Null && !v.Unknown {
+									obj.Map = make(map[string]string, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -1941,8 +1964,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullable.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+								obj.MapObjectNested = nil
 								if !v.Null && !v.Unknown {
+									obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -1986,8 +2010,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullable.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.NestedList = make([]*OtherNested, len(v.Elems))
+								obj.NestedList = nil
 								if !v.Null && !v.Unknown {
+									obj.NestedList = make([]*OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -2067,8 +2092,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullableWithNilValue.Map", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.Map = make(map[string]string, len(v.Elems))
+								obj.Map = nil
 								if !v.Null && !v.Unknown {
+									obj.Map = make(map[string]string, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -2094,8 +2120,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullableWithNilValue.MapObjectNested", "github.com/hashicorp/terraform-plugin-framework/types.Map"})
 							} else {
-								obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
+								obj.MapObjectNested = nil
 								if !v.Null && !v.Unknown {
+									obj.MapObjectNested = make(map[string]OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -2139,8 +2166,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 							if !ok {
 								diags.Append(attrReadConversionFailureDiag{"Test.NestedNullableWithNilValue.NestedList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 							} else {
-								obj.NestedList = make([]*OtherNested, len(v.Elems))
+								obj.NestedList = nil
 								if !v.Null && !v.Unknown {
+									obj.NestedList = make([]*OtherNested, len(v.Elems))
 									for k, a := range v.Elems {
 										v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -2276,8 +2304,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.StringList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.StringList = make([]string, len(v.Elems))
+				obj.StringList = nil
 				if !v.Null && !v.Unknown {
+					obj.StringList = make([]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -2303,8 +2332,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.StringListEmpty", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.StringListEmpty = make([]string, len(v.Elems))
+				obj.StringListEmpty = nil
 				if !v.Null && !v.Unknown {
+					obj.StringListEmpty = make([]string, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -2354,8 +2384,9 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 			if !ok {
 				diags.Append(attrReadConversionFailureDiag{"Test.TimestampList", "github.com/hashicorp/terraform-plugin-framework/types.List"})
 			} else {
-				obj.TimestampList = make([]*time.Time, len(v.Elems))
+				obj.TimestampList = nil
 				if !v.Null && !v.Unknown {
+					obj.TimestampList = make([]*time.Time, len(v.Elems))
 					for k, a := range v.Elems {
 						v, ok := a.(TimeValue)
 						if !ok {
@@ -2732,7 +2763,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				if obj.BytesList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2757,9 +2791,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.BytesList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -2841,7 +2872,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				if obj.DurationCustomList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -2866,9 +2900,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Value = time.Duration(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.DurationCustomList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -3231,7 +3262,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 					}
 				}
-				if obj.Map != nil {
+				if obj.Map == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					for k, a := range obj.Map {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3253,9 +3287,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.Map) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -3285,7 +3316,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObject))
 					}
 				}
-				if obj.MapObject != nil {
+				if obj.MapObject == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObject {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3326,7 +3360,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										if obj.Map == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3348,9 +3385,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Value = string(a)
 												v.Unknown = false
 												c.Elems[k] = v
-											}
-											if len(obj.Map) > 0 {
-												c.Null = false
 											}
 										}
 										c.Unknown = false
@@ -3380,7 +3414,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										if obj.MapObjectNested == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3429,9 +3466,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
@@ -3460,7 +3494,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										if obj.NestedList == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3514,9 +3551,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
@@ -3553,9 +3587,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.MapObject) > 0 {
-						c.Null = false
-					}
 				}
 				c.Unknown = false
 				tf.Attrs["map_object"] = c
@@ -3584,7 +3615,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNullable))
 					}
 				}
-				if obj.MapObjectNullable != nil {
+				if obj.MapObjectNullable == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObjectNullable {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3627,7 +3661,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										if obj.Map == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3649,9 +3686,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Value = string(a)
 												v.Unknown = false
 												c.Elems[k] = v
-											}
-											if len(obj.Map) > 0 {
-												c.Null = false
 											}
 										}
 										c.Unknown = false
@@ -3681,7 +3715,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										if obj.MapObjectNested == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3730,9 +3767,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
@@ -3761,7 +3795,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										if obj.NestedList == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3815,9 +3852,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
@@ -3853,9 +3887,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						}
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.MapObjectNullable) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -3936,7 +3967,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								if obj.Map == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3958,9 +3992,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Value = string(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.Map) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -3990,7 +4021,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								if obj.MapObjectNested == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4039,9 +4073,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
@@ -4070,7 +4101,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								if obj.NestedList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4123,9 +4157,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -4187,7 +4218,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				if obj.NestedList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4231,7 +4265,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										if obj.Map == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4253,9 +4290,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Value = string(a)
 												v.Unknown = false
 												c.Elems[k] = v
-											}
-											if len(obj.Map) > 0 {
-												c.Null = false
 											}
 										}
 										c.Unknown = false
@@ -4285,7 +4319,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										if obj.MapObjectNested == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4334,9 +4371,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
@@ -4365,7 +4399,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										if obj.NestedList == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4419,9 +4456,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
@@ -4458,9 +4492,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedList) > 0 {
-						c.Null = false
-					}
 				}
 				c.Unknown = false
 				tf.Attrs["nested_list"] = c
@@ -4489,7 +4520,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
 					}
 				}
-				if obj.NestedListNullable != nil {
+				if obj.NestedListNullable == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedListNullable) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
@@ -4535,7 +4569,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										if obj.Map == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4557,9 +4594,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Value = string(a)
 												v.Unknown = false
 												c.Elems[k] = v
-											}
-											if len(obj.Map) > 0 {
-												c.Null = false
 											}
 										}
 										c.Unknown = false
@@ -4589,7 +4623,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										if obj.MapObjectNested == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4638,9 +4675,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
@@ -4669,7 +4703,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										if obj.NestedList == nil {
+											c.Null = true
+										} else {
+											c.Null = false
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4723,9 +4760,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
@@ -4761,9 +4795,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						}
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.NestedListNullable) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -4820,7 +4851,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								if obj.Map == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4842,9 +4876,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Value = string(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.Map) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -4874,7 +4905,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								if obj.MapObjectNested == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4923,9 +4957,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
@@ -4954,7 +4985,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								if obj.NestedList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -5007,9 +5041,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -5098,7 +5129,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								if obj.Map == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -5120,9 +5154,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Value = string(a)
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.Map) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -5152,7 +5183,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								if obj.MapObjectNested == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -5201,9 +5235,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
@@ -5232,7 +5263,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								if obj.NestedList == nil {
+									c.Null = true
+								} else {
+									c.Null = false
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -5285,9 +5319,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										v.Unknown = false
 										c.Elems[k] = v
-									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
 									}
 								}
 								c.Unknown = false
@@ -5459,7 +5490,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				if obj.StringList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -5484,9 +5518,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -5516,7 +5547,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
 					}
 				}
-				if obj.StringListEmpty != nil {
+				if obj.StringListEmpty == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.StringListEmpty) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
@@ -5541,9 +5575,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Value = string(a)
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.StringListEmpty) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false
@@ -5608,7 +5639,10 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				if obj.TimestampList == nil {
+					c.Null = true
+				} else {
+					c.Null = false
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
@@ -5636,9 +5670,6 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						}
 						v.Unknown = false
 						c.Elems[k] = v
-					}
-					if len(obj.TimestampList) > 0 {
-						c.Null = false
 					}
 				}
 				c.Unknown = false


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397
Supports https://github.com/gravitational/teleport/issues/60200

This change ensures correct `Null` value is set for list/map type attributes.

### Teleport TF provider and user impact
After upgrading the TF provider, users may see planned state updates because previously empty list/map attributes may now become `Null` values, while previously `Null` values may become empty list/map attributes.