### PR TITLE
Ensure stale map entries are removed

### DIFF
--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1498,6 +1498,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				}
 				if obj.BoolMap != nil {
 					t := o.ElemType
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
 					for k, a := range obj.BoolMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
 						if !ok {
@@ -1976,6 +1977,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				}
 				if obj.IntMap != nil {
 					t := o.ElemType
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.IntMap))
 					for k, a := range obj.IntMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
 						if !ok {
@@ -2201,6 +2203,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				}
 				if obj.NestedMap != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedMap))
 					for k, a := range obj.NestedMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -2518,6 +2521,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				}
 				if obj.NestedNullableMap != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableMap))
 					for k, a := range obj.NestedNullableMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -3440,6 +3444,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				}
 				if obj.StringMap != nil {
 					t := o.ElemType
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
 					for k, a := range obj.StringMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -412,6 +412,11 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 					g.Id("o").Op(":=").Id("o.ElemType").Assert(j.Id(f.i.WithType(f.ElemType)))
 				}
 
+				if f.IsMap {
+					// Rebuild maps on every copy so removed stale entries do not remain in Terraform state.
+					g.Id("c.Elems").Op("=").Add(mk)
+				}
+
 				if f.IsRepeated {
 					// It might happen that we changed the number of elements.
 					// This check creates a new array if that's the case.

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -260,6 +260,23 @@ func TestCopyToMap(t *testing.T) {
 	require.Equal(t, types.String{Null: false, Unknown: false, Value: "value2"}, m["key2"].(types.String))
 }
 
+func TestCopyToMap_RemovesStaleKeys(t *testing.T) {
+	o := copyToTerraformObject(t)
+	testObject := createTestObj()
+
+	diags := CopyTestToTerraform(context.Background(), testObject, &o)
+	requireNoDiagErrors(t, diags)
+	require.Len(t, o.Attrs["map"].(types.Map).Elems, 2)
+
+	testObject.Map = map[string]string{}
+	diags = CopyTestToTerraform(context.Background(), testObject, &o)
+	requireNoDiagErrors(t, diags)
+
+	m := o.Attrs["map"].(types.Map)
+	require.False(t, m.Null)
+	require.Empty(t, m.Elems)
+}
+
 func TestCopyToCustom(t *testing.T) {
 	o := copyToTerraformObject(t)
 

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -494,6 +494,7 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 				}
 				if obj.OptionalMap != nil {
 					t := o.ElemType
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.OptionalMap))
 					for k, a := range obj.OptionalMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -3233,6 +3233,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				}
 				if obj.Map != nil {
 					t := o.ElemType
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 					for k, a := range obj.Map {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 						if !ok {
@@ -3287,6 +3288,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				}
 				if obj.MapObject != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObject))
 					for k, a := range obj.MapObject {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -3328,6 +3330,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.Map != nil {
 											t := o.ElemType
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
@@ -3382,6 +3385,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
@@ -3586,6 +3590,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				}
 				if obj.MapObjectNullable != nil {
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+					c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNullable))
 					for k, a := range obj.MapObjectNullable {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 						if !ok {
@@ -3629,6 +3634,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.Map != nil {
 											t := o.ElemType
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
@@ -3683,6 +3689,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
@@ -3938,6 +3945,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.Map != nil {
 									t := o.ElemType
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -3992,6 +4000,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -4233,6 +4242,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.Map != nil {
 											t := o.ElemType
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
@@ -4287,6 +4297,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
@@ -4537,6 +4548,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.Map != nil {
 											t := o.ElemType
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 												if !ok {
@@ -4591,6 +4603,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										}
 										if obj.MapObjectNested != nil {
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+											c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 												if !ok {
@@ -4822,6 +4835,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.Map != nil {
 									t := o.ElemType
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -4876,6 +4890,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {
@@ -5100,6 +5115,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.Map != nil {
 									t := o.ElemType
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
 										if !ok {
@@ -5154,6 +5170,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 								if obj.MapObjectNested != nil {
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+									c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
 										if !ok {


### PR DESCRIPTION
This change ensures that during `CopyToTerraform` potentially stale map entries are removed.

I can't think of a valid scenario with the Teleport Terraform provider when this edge case would be hit. So this change might be better left as part of a larger refactoring change.