### PR TITLE
Normalize null lists and maps

### DIFF
--- a/examples/testlib/provider/resource_objects.go
+++ b/examples/testlib/provider/resource_objects.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -53,9 +54,24 @@ func (r objectsResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 		return
 	}
 
-	r.p.objects[id] = objects
+	// We proto marshall and unmarshall the resource to test stability through proto round-trip.
+	// This is required because protouf does not preserve the distinction between nil and empty
+	// for some types (lists for examples).
+	wireMsg, err := proto.Marshal(objects)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to proto marshal", err.Error())
+		return
+	}
 
-	resp.Diagnostics.Append(schemav1.CopyObjectsToTerraform(ctx, objects, &plan)...)
+	var newObjects extypes.Objects
+	if err := proto.Unmarshal(wireMsg, &newObjects); err != nil {
+		resp.Diagnostics.AddError("failed to proto unmarshal", err.Error())
+		return
+	}
+
+	r.p.objects[id] = &newObjects
+
+	resp.Diagnostics.Append(schemav1.CopyObjectsToTerraform(ctx, &newObjects, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -101,7 +117,24 @@ func (r objectsResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 
 	r.p.objects[objects.Id] = objects
 
-	resp.Diagnostics.Append(schemav1.CopyObjectsToTerraform(ctx, objects, &plan)...)
+	// We proto marshall and unmarshall the resource to test stability through proto round-trip.
+	// This is required because protouf does not preserve the distinction between nil and empty
+	// for some types (lists for examples).
+	wireMsg, err := proto.Marshal(objects)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to proto marshal", err.Error())
+		return
+	}
+
+	var newObjects extypes.Objects
+	if err := proto.Unmarshal(wireMsg, &newObjects); err != nil {
+		resp.Diagnostics.AddError("failed to proto unmarshal", err.Error())
+		return
+	}
+
+	r.p.objects[newObjects.Id] = &newObjects
+
+	resp.Diagnostics.Append(schemav1.CopyObjectsToTerraform(ctx, &newObjects, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/examples/testlib/provider/resource_primitives.go
+++ b/examples/testlib/provider/resource_primitives.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -53,9 +54,24 @@ func (r primitivesResource) Create(ctx context.Context, req tfsdk.CreateResource
 		return
 	}
 
-	r.p.primitives[id] = primitives
+	// We proto marshall and unmarshall the resource to test stability through proto round-trip.
+	// This is required because protouf does not preserve the distinction between nil and empty
+	// for some types (lists for examples).
+	wireMsg, err := proto.Marshal(primitives)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to proto marshal", err.Error())
+		return
+	}
 
-	resp.Diagnostics.Append(schemav1.CopyPrimitivesToTerraform(ctx, primitives, &plan)...)
+	var newPrimitives extypes.Primitives
+	if err := proto.Unmarshal(wireMsg, &newPrimitives); err != nil {
+		resp.Diagnostics.AddError("failed to proto unmarshal", err.Error())
+		return
+	}
+
+	r.p.primitives[id] = &newPrimitives
+
+	resp.Diagnostics.Append(schemav1.CopyPrimitivesToTerraform(ctx, &newPrimitives, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -99,9 +115,24 @@ func (r primitivesResource) Update(ctx context.Context, req tfsdk.UpdateResource
 		return
 	}
 
-	r.p.primitives[primitives.Id] = primitives
+	// We proto marshall and unmarshall the resource to test stability through proto round-trip.
+	// This is required because protouf does not preserve the distinction between nil and empty
+	// for some types (lists for examples).
+	wireMsg, err := proto.Marshal(primitives)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to proto marshal", err.Error())
+		return
+	}
 
-	resp.Diagnostics.Append(schemav1.CopyPrimitivesToTerraform(ctx, primitives, &plan)...)
+	var newPrimitives extypes.Primitives
+	if err := proto.Unmarshal(wireMsg, &newPrimitives); err != nil {
+		resp.Diagnostics.AddError("failed to proto unmarshal", err.Error())
+		return
+	}
+
+	r.p.primitives[newPrimitives.Id] = &newPrimitives
+
+	resp.Diagnostics.Append(schemav1.CopyPrimitivesToTerraform(ctx, &newPrimitives, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -42,9 +42,11 @@ var _ = math.Inf
 func GenSchemaObjects(ctx context.Context) (github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema, github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics) {
 	return github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 		"bool_map": {
-			Description: "bool_map map of bools.",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.BoolType},
+			Computed:      true,
+			Description:   "bool_map map of bools.",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.BoolType},
 		},
 		"branch_bool": {
 			Computed:      true,
@@ -130,9 +132,11 @@ func GenSchemaObjects(ctx context.Context) (github_com_hashicorp_terraform_plugi
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"int_map": {
-			Description: "int_map map of ints.",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.Int64Type},
+			Computed:      true,
+			Description:   "int_map map of ints.",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.Int64Type},
 		},
 		"leaf": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": {
@@ -216,8 +220,10 @@ func GenSchemaObjects(ctx context.Context) (github_com_hashicorp_terraform_plugi
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 			}}),
-			Description: "nested_nullable_list is a nullable list of nested objects.",
-			Optional:    true,
+			Computed:      true,
+			Description:   "nested_nullable_list is a nullable list of nested objects.",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"nested_nullable_map": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": {
@@ -233,8 +239,10 @@ func GenSchemaObjects(ctx context.Context) (github_com_hashicorp_terraform_plugi
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 			}}),
-			Description: "nested_map is a nullable map of nested objects.",
-			Optional:    true,
+			Computed:      true,
+			Description:   "nested_map is a nullable map of nested objects.",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"nested_value": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": {
@@ -383,9 +391,11 @@ func GenSchemaObjects(ctx context.Context) (github_com_hashicorp_terraform_plugi
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"string_map": {
-			Description: "string_map map of strings.",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+			Computed:      true,
+			Description:   "string_map map of strings.",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 		},
 	}}, nil
 }

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1496,7 +1496,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolMap))
 					}
 				}
-				if obj.BoolMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.BoolMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
@@ -1519,10 +1519,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.BoolMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["bool_map"] = c
 			}
@@ -1974,7 +1972,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.IntMap))
 					}
 				}
-				if obj.IntMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.IntMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -1997,10 +1995,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.IntMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["int_map"] = c
 			}
@@ -2085,7 +2081,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -2168,10 +2164,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_list"] = c
 			}
@@ -2199,7 +2193,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedMap))
 					}
 				}
-				if obj.NestedMap != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2279,10 +2273,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_map"] = c
 			}
@@ -2400,7 +2392,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
 					}
 				}
-				if obj.NestedNullableList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedNullableList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
@@ -2485,10 +2477,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedNullableList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_nullable_list"] = c
 			}
@@ -2516,7 +2506,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableMap))
 					}
 				}
-				if obj.NestedNullableMap != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.NestedNullableMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2598,10 +2588,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedNullableMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_nullable_map"] = c
 			}
@@ -2742,7 +2730,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 									}
 								}
-								if obj.BoolList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -2768,10 +2756,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.BoolList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["bool_list"] = c
 							}
@@ -2825,7 +2811,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 									}
 								}
-								if obj.BytesList != nil {
+								{
 									t := o.ElemType
 									if len(obj.BytesList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2851,10 +2837,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.BytesList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["bytes_list"] = c
 							}
@@ -2908,7 +2892,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 									}
 								}
-								if obj.DoubleList != nil {
+								{
 									t := o.ElemType
 									if len(obj.DoubleList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -2934,10 +2918,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.DoubleList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["double_list"] = c
 							}
@@ -2991,7 +2973,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 									}
 								}
-								if obj.EnumList != nil {
+								{
 									t := o.ElemType
 									if len(obj.EnumList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -3017,10 +2999,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.EnumList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["enum_list"] = c
 							}
@@ -3074,7 +3054,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 									}
 								}
-								if obj.FloatList != nil {
+								{
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -3100,10 +3080,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.FloatList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["float_list"] = c
 							}
@@ -3183,7 +3161,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 									}
 								}
-								if obj.Int32List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int32List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -3209,10 +3187,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.Int32List) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["int32_list"] = c
 							}
@@ -3266,7 +3242,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 									}
 								}
-								if obj.Int64List != nil {
+								{
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -3292,10 +3268,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.Int64List) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["int64_list"] = c
 							}
@@ -3349,7 +3323,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 									}
 								}
-								if obj.StringList != nil {
+								{
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -3375,10 +3349,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.StringList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["string_list"] = c
 							}
@@ -3438,7 +3410,7 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringMap))
 					}
 				}
-				if obj.StringMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.StringMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3461,10 +3433,8 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.StringMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["string_map"] = c
 			}

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -568,7 +568,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
 					}
 				}
-				if obj.BoolList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BoolList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
@@ -594,10 +594,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.BoolList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["bool_list"] = c
 			}
@@ -651,7 +649,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -677,10 +675,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.BytesList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["bytes_list"] = c
 			}
@@ -734,7 +730,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
 					}
 				}
-				if obj.DoubleList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DoubleList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
@@ -760,10 +756,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.DoubleList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["double_list"] = c
 			}
@@ -817,7 +811,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
 					}
 				}
-				if obj.EnumList != nil {
+				{
 					t := o.ElemType
 					if len(obj.EnumList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
@@ -843,10 +837,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.EnumList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["enum_list"] = c
 			}
@@ -900,7 +892,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
 					}
 				}
-				if obj.FloatList != nil {
+				{
 					t := o.ElemType
 					if len(obj.FloatList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
@@ -926,10 +918,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.FloatList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["float_list"] = c
 			}
@@ -1009,7 +999,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
 					}
 				}
-				if obj.Int32List != nil {
+				{
 					t := o.ElemType
 					if len(obj.Int32List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
@@ -1035,10 +1025,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.Int32List) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["int32_list"] = c
 			}
@@ -1092,7 +1080,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
 					}
 				}
-				if obj.Int64List != nil {
+				{
 					t := o.ElemType
 					if len(obj.Int64List) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
@@ -1118,10 +1106,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.Int64List) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["int64_list"] = c
 			}
@@ -1175,7 +1161,7 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -1201,10 +1187,8 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["string_list"] = c
 			}

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -354,7 +354,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -380,10 +380,8 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.DurationCustomList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["duration_custom_list"] = c
 			}
@@ -411,7 +409,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
 					}
 				}
-				if obj.DurationList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
@@ -437,10 +435,8 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.DurationList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["duration_list"] = c
 			}
@@ -578,7 +574,7 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
@@ -604,10 +600,8 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.TimestampList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["timestamp_list"] = c
 			}

--- a/field_build_context.go
+++ b/field_build_context.go
@@ -445,6 +445,17 @@ func (c *FieldBuildContext) IsComputed(isProto3optional bool) bool {
 	if c.GetFlagValue(c.config.ComputedFields) {
 		return true
 	}
+
+	// Go allows list and map attributes to be `nil`, but protobuf does not preserve
+	// this distinction. As a result, they may appear as either `null` or empty,
+	// though the backend treats them identically.
+	//
+	// To ensure consistency, `nil` values are normalized to empty values, making
+	// list and map attributes effectively non-nullable and computed as empty by default.
+	if c.IsRepeated() || c.IsMap() {
+		return true
+	}
+
 	// If the field is nullable or optional, the Terraform `Null` value can be represented
 	// in the go struct as a `nil` pointer. This allows us to successfully round-trip through
 	// the go type: `ToTerraform(FromTerraform(field)) == field`.

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -405,7 +405,7 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 				),
 			)
 
-			g.If(j.Id(fieldName)).Op("!=").Nil().BlockFunc(func(g *j.Group) {
+			g.BlockFunc(func(g *j.Group) {
 				if (f.Kind == PrimitiveListKind) || (f.Kind == PrimitiveMapKind) {
 					g.Id("t").Op(":=").Id("o.ElemType")
 				} else {
@@ -436,13 +436,10 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 					}
 					g.Id("c.Elems").Index(j.Id("k")).Op("=").Id("v")
 				})
-
-				// if len(obj.Test) > 0
-				g.If(j.Len(j.Id(fieldName))).Op(">").Lit(0).Block(
-					j.Id("c.Null").Op("=").False(),
-				)
 			})
 
+			// List and Map attributes are normalized to an empty value
+			g.Id("c.Null").Op("=").False()
 			g.Id("c.Unknown").Op("=").False()
 			g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("c")
 		})

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -125,7 +125,7 @@ func TestCopyToList(t *testing.T) {
 	}, o.Attrs["string_list"].(types.List).Elems)
 
 	require.Equal(t, types.List{
-		Null:     true,
+		Null:     false,
 		Unknown:  false,
 		Elems:    make([]attr.Value, 0),
 		ElemType: types.StringType,

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -492,7 +492,7 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.OptionalMap))
 					}
 				}
-				if obj.OptionalMap != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.OptionalMap {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -515,10 +515,8 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.OptionalMap) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["optional_map"] = c
 			}
@@ -575,7 +573,7 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -601,10 +599,8 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["string_list"] = c
 			}

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -71,6 +71,7 @@ func GenSchemaOptionalTest(ctx context.Context) (github_com_hashicorp_terraform_
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
 		"optional_map": {
+			Computed:    true,
 			Description: "maps don't support optional keyword, but we add it here to check the generation",
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},

--- a/test/optional/optional_test.go
+++ b/test/optional/optional_test.go
@@ -137,7 +137,7 @@ func TestCopyToOptionalFieldsNil(t *testing.T) {
 	require.True(t, o.Attrs["optional_bool"].(types.Bool).Null)
 	require.True(t, o.Attrs["optional_inner_message"].(types.Object).Null)
 
-	// Nil map and slice set with Null true on the Terraform side.
+	// Nil map and slice are normalized to the empty value on the Terraform side.
 	require.False(t, o.Attrs["optional_map"].(types.Map).Null)
 	require.False(t, o.Attrs["string_list"].(types.List).Null)
 }

--- a/test/optional/optional_test.go
+++ b/test/optional/optional_test.go
@@ -138,8 +138,8 @@ func TestCopyToOptionalFieldsNil(t *testing.T) {
 	require.True(t, o.Attrs["optional_inner_message"].(types.Object).Null)
 
 	// Nil map and slice set with Null true on the Terraform side.
-	require.True(t, o.Attrs["optional_map"].(types.Map).Null)
-	require.True(t, o.Attrs["string_list"].(types.List).Null)
+	require.False(t, o.Attrs["optional_map"].(types.Map).Null)
+	require.False(t, o.Attrs["string_list"].(types.List).Null)
 }
 
 func TestCopyFromOptionalFields(t *testing.T) {

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2732,7 +2732,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
 					}
 				}
-				if obj.BytesList != nil {
+				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
@@ -2758,10 +2758,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.BytesList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["bytes_list"] = c
 			}
@@ -2841,7 +2839,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
 					}
 				}
-				if obj.DurationCustomList != nil {
+				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
@@ -2867,10 +2865,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.DurationCustomList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["duration_custom_list"] = c
 			}
@@ -3231,7 +3227,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 					}
 				}
-				if obj.Map != nil {
+				{
 					t := o.ElemType
 					for k, a := range obj.Map {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3254,10 +3250,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.Map) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["map"] = c
 			}
@@ -3285,7 +3279,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObject))
 					}
 				}
-				if obj.MapObject != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObject {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3326,7 +3320,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3349,10 +3343,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.Map) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map"] = c
 									}
@@ -3380,7 +3372,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3429,10 +3421,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
 									}
@@ -3460,7 +3450,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3514,10 +3504,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
 									}
@@ -3553,10 +3541,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.MapObject) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["map_object"] = c
 			}
@@ -3584,7 +3570,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNullable))
 					}
 				}
-				if obj.MapObjectNullable != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					for k, a := range obj.MapObjectNullable {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3627,7 +3613,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3650,10 +3636,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.Map) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map"] = c
 									}
@@ -3681,7 +3665,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3730,10 +3714,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
 									}
@@ -3761,7 +3743,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -3815,10 +3797,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
 									}
@@ -3854,10 +3834,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.MapObjectNullable) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["map_object_nullable"] = c
 			}
@@ -3936,7 +3914,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3959,10 +3937,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.Map) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map"] = c
 							}
@@ -3990,7 +3966,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4039,10 +4015,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
 							}
@@ -4070,7 +4044,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4124,10 +4098,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["nested_list"] = c
 							}
@@ -4187,7 +4159,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 					}
 				}
-				if obj.NestedList != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4231,7 +4203,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4254,10 +4226,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.Map) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map"] = c
 									}
@@ -4285,7 +4255,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4334,10 +4304,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
 									}
@@ -4365,7 +4333,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4419,10 +4387,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
 									}
@@ -4458,10 +4424,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_list"] = c
 			}
@@ -4489,7 +4453,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
 					}
 				}
-				if obj.NestedListNullable != nil {
+				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedListNullable) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
@@ -4535,7 +4499,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 											}
 										}
-										if obj.Map != nil {
+										{
 											t := o.ElemType
 											for k, a := range obj.Map {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4558,10 +4522,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.Map) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map"] = c
 									}
@@ -4589,7 +4551,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 											}
 										}
-										if obj.MapObjectNested != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											for k, a := range obj.MapObjectNested {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4638,10 +4600,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.MapObjectNested) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["map_object_nested"] = c
 									}
@@ -4669,7 +4629,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 											}
 										}
-										if obj.NestedList != nil {
+										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
 												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -4723,10 +4683,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 												v.Unknown = false
 												c.Elems[k] = v
 											}
-											if len(obj.NestedList) > 0 {
-												c.Null = false
-											}
 										}
+										c.Null = false
 										c.Unknown = false
 										tf.Attrs["nested_list"] = c
 									}
@@ -4762,10 +4720,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.NestedListNullable) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["nested_list_nullable"] = c
 			}
@@ -4820,7 +4776,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -4843,10 +4799,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.Map) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map"] = c
 							}
@@ -4874,7 +4828,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4923,10 +4877,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
 							}
@@ -4954,7 +4906,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -5008,10 +4960,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["nested_list"] = c
 							}
@@ -5098,7 +5048,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Map))
 									}
 								}
-								if obj.Map != nil {
+								{
 									t := o.ElemType
 									for k, a := range obj.Map {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -5121,10 +5071,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.Map) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map"] = c
 							}
@@ -5152,7 +5100,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.MapObjectNested))
 									}
 								}
-								if obj.MapObjectNested != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									for k, a := range obj.MapObjectNested {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -5201,10 +5149,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.MapObjectNested) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["map_object_nested"] = c
 							}
@@ -5232,7 +5178,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
 									}
 								}
-								if obj.NestedList != nil {
+								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
 										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
@@ -5286,10 +5232,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 										v.Unknown = false
 										c.Elems[k] = v
 									}
-									if len(obj.NestedList) > 0 {
-										c.Null = false
-									}
 								}
+								c.Null = false
 								c.Unknown = false
 								tf.Attrs["nested_list"] = c
 							}
@@ -5459,7 +5403,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
 					}
 				}
-				if obj.StringList != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
@@ -5485,10 +5429,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.StringList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["string_list"] = c
 			}
@@ -5516,7 +5458,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
 					}
 				}
-				if obj.StringListEmpty != nil {
+				{
 					t := o.ElemType
 					if len(obj.StringListEmpty) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
@@ -5542,10 +5484,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.StringListEmpty) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["string_list_empty"] = c
 			}
@@ -5608,7 +5548,7 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
 					}
 				}
-				if obj.TimestampList != nil {
+				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
 						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
@@ -5637,10 +5577,8 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 						v.Unknown = false
 						c.Elems[k] = v
 					}
-					if len(obj.TimestampList) > 0 {
-						c.Null = false
-					}
 				}
+				c.Null = false
 				c.Unknown = false
 				tf.Attrs["timestamp_list"] = c
 			}

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -211,16 +211,20 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
 		"map": {
-			Description: "Map normal map",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+			Computed:      true,
+			Description:   "Map normal map",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 		},
 		"map_object": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -243,8 +247,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -262,9 +268,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 		"map_object_nullable": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -287,8 +295,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -298,8 +308,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
-			Description: "MapObjectNullable is the object map with nullable values",
-			Optional:    true,
+			Computed:      true,
+			Description:   "MapObjectNullable is the object map with nullable values",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"max_age": {
 			Computed:      true,
@@ -318,9 +330,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 		"nested": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -343,8 +357,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -362,9 +378,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 		"nested_list": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -387,8 +405,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -406,9 +426,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 		"nested_list_nullable": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -431,8 +453,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -442,15 +466,19 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 			}),
-			Description: "NestedListNullable nested message array",
-			Optional:    true,
+			Computed:      true,
+			Description:   "NestedListNullable nested message array",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 		},
 		"nested_nullable": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -473,8 +501,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -490,9 +520,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 		"nested_nullable_with_nil_value": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"map": {
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+					Computed:      true,
+					Description:   "Nested map repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
 				"map_object_nested": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": {
@@ -515,8 +547,10 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 					}}),
-					Description: "Nested repeated nested messages",
-					Optional:    true,
+					Computed:      true,
+					Description:   "Nested repeated nested messages",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 				},
 				"str": {
 					Computed:      true,
@@ -585,9 +619,11 @@ func GenSchemaTest(ctx context.Context) (github_com_hashicorp_terraform_plugin_f
 			Type:          UseRFC3339Time(),
 		},
 		"timestamp_list": {
-			Description: "TimestampList []time.Time field",
-			Optional:    true,
-			Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: UseRFC3339Time()},
+			Computed:      true,
+			Description:   "TimestampList []time.Time field",
+			Optional:      true,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: UseRFC3339Time()},
 		},
 		"timestamp_missing": {
 			Computed:      true,


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397

Currently, Terraform state can contain both null and empty values for lists and maps. The values are semantically the same after a round trip using protobuf. This is because protobuf does not preserve this distinction between empty and null values.

The reason for the change is because the inconsistency is a bit confusing and it makes it more difficult to validate Terraform state.

With this change, null lists and maps will now be normalized to the empty value. List and map type attributes will also be treated as non-nullable and default to `computed`.