### PR TITLE
Preserve Unknown values

### DIFF
--- a/examples/config/custom.yaml
+++ b/examples/config/custom.yaml
@@ -12,6 +12,8 @@ injected_fields:
     - name: injected
       type: github.com/hashicorp/terraform-plugin-framework/types.StringType
       computed: true
+      plan_modifiers:
+        - "github.com/hashicorp/terraform-plugin-framework/tfsdk.UseStateForUnknown()"
 
 computed_fields:
   - Custom.id

--- a/examples/testlib/custom_test.go
+++ b/examples/testlib/custom_test.go
@@ -67,3 +67,43 @@ func (s *TerraformSuite) TestCustomNullValues() {
 		},
 	})
 }
+
+func (s *TerraformSuite) TestCustomPreserveUnknown() {
+	// TODO: This test currently fails with an `invalid plan` error
+	//
+	// Error: Provider produced invalid plan
+	// Provider "registry.terraform.io/hashicorp/example" planned an invalid value
+	// for example_custom.preserve_unknown.required: planned value cty.StringVal("")
+	// does not match config value cty.UnknownVal(cty.String) nor prior value
+	// cty.StringVal("required").
+
+	t := s.T()
+	name := "example_custom.preserve_unknown"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("custom_preserve_unknown_1.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "required", "required"),
+				),
+			},
+			{
+				Config:   s.getFixture("custom_preserve_unknown_1.tf"),
+				PlanOnly: true,
+			},
+			{
+				Config: s.getFixture("custom_preserve_unknown_2.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "required", "computed"),
+				),
+			},
+			{
+				Config:   s.getFixture("custom_preserve_unknown_2.tf"),
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/examples/testlib/custom_test.go
+++ b/examples/testlib/custom_test.go
@@ -69,14 +69,6 @@ func (s *TerraformSuite) TestCustomNullValues() {
 }
 
 func (s *TerraformSuite) TestCustomPreserveUnknown() {
-	// TODO: This test currently fails with an `invalid plan` error
-	//
-	// Error: Provider produced invalid plan
-	// Provider "registry.terraform.io/hashicorp/example" planned an invalid value
-	// for example_custom.preserve_unknown.required: planned value cty.StringVal("")
-	// does not match config value cty.UnknownVal(cty.String) nor prior value
-	// cty.StringVal("required").
-
 	t := s.T()
 	name := "example_custom.preserve_unknown"
 

--- a/examples/testlib/fixtures/custom_preserve_unknown_1.tf
+++ b/examples/testlib/fixtures/custom_preserve_unknown_1.tf
@@ -1,0 +1,3 @@
+resource "example_custom" "preserve_unknown" {
+  required = "required"
+}

--- a/examples/testlib/fixtures/custom_preserve_unknown_2.tf
+++ b/examples/testlib/fixtures/custom_preserve_unknown_2.tf
@@ -1,0 +1,7 @@
+resource "example_custom" "reference" {
+  required = "required"
+}
+
+resource "example_custom" "preserve_unknown" {
+  required = example_custom.reference.computed
+}

--- a/examples/testlib/provider/resource_custom.go
+++ b/examples/testlib/provider/resource_custom.go
@@ -126,3 +126,42 @@ func (r customResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequ
 
 	delete(r.p.custom, id.Value)
 }
+
+func (r customResource) ModifyPlan(ctx context.Context, req tfsdk.ModifyResourcePlanRequest, resp *tfsdk.ModifyResourcePlanResponse) {
+	// If the entire plan is null, the resource is planned for destruction.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan types.Object
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Preserve the provider-managed ID, but rewrite all other fields from
+	// config so omitted or null values become explicit zero values in the plan.
+	id, hasID := plan.Attrs["id"]
+
+	custom := &extypes.Custom{}
+	resp.Diagnostics.Append(schemav1.CopyCustomFromTerraform(ctx, plan, custom)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// resp.Diagnostics.Append(schemav1.CopyCustomToTerraformPreserveUnknown(ctx, custom, &plan, true)...)
+	resp.Diagnostics.Append(schemav1.CopyCustomToTerraform(ctx, custom, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if hasID {
+		plan.Attrs["id"] = id
+	}
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}

--- a/examples/testlib/provider/resource_custom.go
+++ b/examples/testlib/provider/resource_custom.go
@@ -153,8 +153,7 @@ func (r customResource) ModifyPlan(ctx context.Context, req tfsdk.ModifyResource
 		return
 	}
 
-	// resp.Diagnostics.Append(schemav1.CopyCustomToTerraformPreserveUnknown(ctx, custom, &plan, true)...)
-	resp.Diagnostics.Append(schemav1.CopyCustomToTerraform(ctx, custom, &plan)...)
+	resp.Diagnostics.Append(schemav1.CopyCustomToTerraformPreserveUnknown(ctx, custom, &plan, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/examples/tfschema/custom/v1/custom_terraform.go
+++ b/examples/tfschema/custom/v1/custom_terraform.go
@@ -75,10 +75,11 @@ func GenSchemaCustom(ctx context.Context) (github_com_hashicorp_terraform_plugin
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"injected": {
-			Computed: true,
-			Optional: false,
-			Required: false,
-			Type:     github_com_hashicorp_terraform_plugin_framework_types.StringType,
+			Computed:      true,
+			Optional:      false,
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+			Required:      false,
+			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"plan_modifier": {
 			Computed:      true,

--- a/examples/tfschema/custom/v1/custom_terraform.go
+++ b/examples/tfschema/custom/v1/custom_terraform.go
@@ -290,6 +290,12 @@ func CopyCustomFromTerraform(_ context.Context, tf github_com_hashicorp_terrafor
 
 // CopyCustomToTerraform copies contents of the source Terraform object into a target struct
 func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Custom, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyCustomToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyCustomToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyCustomToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Custom, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -336,7 +342,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.Computed)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["computed"] = v
 		}
 	}
@@ -362,7 +370,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.Id)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["id"] = v
 		}
 	}
@@ -388,7 +398,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.NameOverride)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["custom_name_override"] = v
 		}
 	}
@@ -414,7 +426,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.PlanModifier)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["plan_modifier"] = v
 		}
 	}
@@ -440,7 +454,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.Required)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["required"] = v
 		}
 	}
@@ -466,7 +482,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.SchemaOverride)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["schema_override"] = v
 		}
 	}
@@ -492,7 +510,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.Sensitive)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["sensitive"] = v
 		}
 	}
@@ -527,7 +547,9 @@ func CopyCustomToTerraform(ctx context.Context, obj *github_com_gravitational_pr
 
 			v.Null = false
 			v.Value = string(obj.Validated)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["validated"] = v
 		}
 	}

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -1478,6 +1478,12 @@ func CopyObjectsFromTerraform(_ context.Context, tf github_com_hashicorp_terrafo
 
 // CopyObjectsToTerraform copies contents of the source Terraform object into a target struct
 func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Objects, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyObjectsToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyObjectsToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Objects, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -1526,12 +1532,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 						v.Null = false
 						v.Value = bool(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["bool_map"] = c
 			}
 		}
@@ -1564,7 +1574,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					v.Value = bool(obj.BranchBool)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["branch_bool"] = v
 		}
 	}
@@ -1618,12 +1630,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 								}
 							}
 							v.Null = true
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["active"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["branch_empty"] = v
 			}
 		}
@@ -1656,7 +1672,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					v.Value = int64(obj.BranchInt)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["branch_int"] = v
 		}
 	}
@@ -1713,12 +1731,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = string(obj.Value)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["value"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["branch_leaf"] = v
 			}
 		}
@@ -1801,18 +1823,24 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 											v.Null = false
 											v.Value = string(obj.Value)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["value"] = v
 										}
 									}
 								}
-								v.Unknown = false
+								if !preserveUnknown {
+									v.Unknown = false
+								}
 								tf.Attrs["leaf"] = v
 							}
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["branch_nested"] = v
 			}
 		}
@@ -1845,7 +1873,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 					v.Value = string(obj.BranchString)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["branch_string"] = v
 		}
 	}
@@ -1874,7 +1904,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 				v.Null = false
 				v.Value = string(obj.EmbeddedValue)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["embedded_value"] = v
 		}
 	}
@@ -1924,12 +1956,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 								}
 							}
 							v.Null = true
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["active"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["empty"] = v
 			}
 		}
@@ -1956,7 +1992,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 			v.Null = false
 			v.Value = string(obj.Id)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["id"] = v
 		}
 	}
@@ -2002,12 +2040,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 						v.Null = false
 						v.Value = int64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["int_map"] = c
 			}
 		}
@@ -2059,12 +2101,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = string(obj.Value)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["value"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["leaf"] = v
 			}
 		}
@@ -2160,23 +2206,31 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 													v.Null = false
 													v.Value = string(obj.Value)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["value"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										tf.Attrs["leaf"] = v
 									}
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_list"] = c
 			}
 		}
@@ -2269,23 +2323,31 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 													v.Null = false
 													v.Value = string(obj.Value)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["value"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										tf.Attrs["leaf"] = v
 									}
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_map"] = c
 			}
 		}
@@ -2364,18 +2426,24 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 											v.Null = false
 											v.Value = string(obj.Value)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["value"] = v
 										}
 									}
 								}
-								v.Unknown = false
+								if !preserveUnknown {
+									v.Unknown = false
+								}
 								tf.Attrs["leaf"] = v
 							}
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["nested_nullable"] = v
 			}
 		}
@@ -2473,23 +2541,31 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 													v.Null = false
 													v.Value = string(obj.Value)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["value"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										tf.Attrs["leaf"] = v
 									}
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_nullable_list"] = c
 			}
 		}
@@ -2584,23 +2660,31 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 													v.Null = false
 													v.Value = string(obj.Value)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["value"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										tf.Attrs["leaf"] = v
 									}
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_nullable_map"] = c
 			}
 		}
@@ -2677,18 +2761,24 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 											v.Null = false
 											v.Value = string(obj.Value)
-											v.Unknown = false
+											if !preserveUnknown {
+												v.Unknown = false
+											}
 											tf.Attrs["value"] = v
 										}
 									}
 								}
-								v.Unknown = false
+								if !preserveUnknown {
+									v.Unknown = false
+								}
 								tf.Attrs["leaf"] = v
 							}
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["nested_value"] = v
 			}
 		}
@@ -2763,12 +2853,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = bool(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["bool_list"] = c
 							}
 						}
@@ -2795,7 +2889,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = bool(obj.BoolValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["bool_value"] = v
 						}
 					}
@@ -2844,12 +2940,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["bytes_list"] = c
 							}
 						}
@@ -2876,7 +2976,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = string(obj.BytesValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["bytes_value"] = v
 						}
 					}
@@ -2925,12 +3027,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = float64(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["double_list"] = c
 							}
 						}
@@ -2957,7 +3063,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = float64(obj.DoubleValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["double_value"] = v
 						}
 					}
@@ -3006,12 +3114,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = int64(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["enum_list"] = c
 							}
 						}
@@ -3038,7 +3150,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = int64(obj.EnumValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["enum_value"] = v
 						}
 					}
@@ -3087,12 +3201,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = float64(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["float_list"] = c
 							}
 						}
@@ -3119,7 +3237,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = float64(obj.FloatValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["float_value"] = v
 						}
 					}
@@ -3145,7 +3265,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = string(obj.Id)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["id"] = v
 						}
 					}
@@ -3194,12 +3316,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = int64(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["int32_list"] = c
 							}
 						}
@@ -3226,7 +3352,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = int64(obj.Int32Value)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["int32_value"] = v
 						}
 					}
@@ -3275,12 +3403,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = int64(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["int64_list"] = c
 							}
 						}
@@ -3307,7 +3439,9 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = int64(obj.Int64Value)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["int64_value"] = v
 						}
 					}
@@ -3356,12 +3490,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["string_list"] = c
 							}
 						}
@@ -3388,12 +3526,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 							v.Null = false
 							v.Value = string(obj.StringValue)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["string_value"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["primitives"] = v
 			}
 		}
@@ -3440,12 +3582,16 @@ func CopyObjectsToTerraform(ctx context.Context, obj *github_com_gravitational_p
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["string_map"] = c
 			}
 		}

--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -2140,7 +2140,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.NestedList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2473,7 +2475,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedNullableList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedNullableList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.NestedNullableList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -2833,7 +2837,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.BoolList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.BoolList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
@@ -2920,7 +2926,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.BytesList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.BytesList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -3007,7 +3015,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.DoubleList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.DoubleList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
@@ -3094,7 +3104,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.EnumList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.EnumList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -3181,7 +3193,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.FloatList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.FloatList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
@@ -3296,7 +3310,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.Int32List) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.Int32List {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -3383,7 +3399,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.Int64List) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.Int64List {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -3470,7 +3488,9 @@ func CopyObjectsToTerraformPreserveUnknown(ctx context.Context, obj *github_com_
 								{
 									t := o.ElemType
 									if len(obj.StringList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.StringList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -540,6 +540,12 @@ func CopyPrimitivesFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 
 // CopyPrimitivesToTerraform copies contents of the source Terraform object into a target struct
 func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Primitives, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyPrimitivesToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyPrimitivesToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Primitives, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -591,12 +597,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = bool(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["bool_list"] = c
 			}
 		}
@@ -623,7 +633,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = bool(obj.BoolValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["bool_value"] = v
 		}
 	}
@@ -672,12 +684,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["bytes_list"] = c
 			}
 		}
@@ -704,7 +720,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = string(obj.BytesValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["bytes_value"] = v
 		}
 	}
@@ -753,12 +771,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = float64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["double_list"] = c
 			}
 		}
@@ -785,7 +807,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = float64(obj.DoubleValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["double_value"] = v
 		}
 	}
@@ -834,12 +858,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = int64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["enum_list"] = c
 			}
 		}
@@ -866,7 +894,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = int64(obj.EnumValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["enum_value"] = v
 		}
 	}
@@ -915,12 +945,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = float64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["float_list"] = c
 			}
 		}
@@ -947,7 +981,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = float64(obj.FloatValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["float_value"] = v
 		}
 	}
@@ -973,7 +1009,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = string(obj.Id)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["id"] = v
 		}
 	}
@@ -1022,12 +1060,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = int64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["int32_list"] = c
 			}
 		}
@@ -1054,7 +1096,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = int64(obj.Int32Value)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["int32_value"] = v
 		}
 	}
@@ -1103,12 +1147,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = int64(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["int64_list"] = c
 			}
 		}
@@ -1135,7 +1183,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = int64(obj.Int64Value)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["int64_value"] = v
 		}
 	}
@@ -1184,12 +1234,16 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["string_list"] = c
 			}
 		}
@@ -1216,7 +1270,9 @@ func CopyPrimitivesToTerraform(ctx context.Context, obj *github_com_gravitationa
 
 			v.Null = false
 			v.Value = string(obj.StringValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["string_value"] = v
 		}
 	}

--- a/examples/tfschema/primitives/v1/primitives_terraform.go
+++ b/examples/tfschema/primitives/v1/primitives_terraform.go
@@ -577,7 +577,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.BoolList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BoolList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.BoolList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
@@ -664,7 +666,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.BytesList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -751,7 +755,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.DoubleList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DoubleList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.DoubleList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
@@ -838,7 +844,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.EnumList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.EnumList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.EnumList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -925,7 +933,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.FloatList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.FloatList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.FloatList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Float64)
@@ -1040,7 +1050,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.Int32List) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int32List))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.Int32List {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -1127,7 +1139,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.Int64List) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Int64List))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.Int64List {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Int64)
@@ -1214,7 +1228,9 @@ func CopyPrimitivesToTerraformPreserveUnknown(ctx context.Context, obj *github_c
 				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.StringList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -365,7 +365,9 @@ func CopyTimeToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gra
 				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.DurationCustomList {
 						v, ok := c.Elems[k].(DurationValue)
@@ -424,7 +426,9 @@ func CopyTimeToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gra
 				{
 					t := o.ElemType
 					if len(obj.DurationList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.DurationList {
 						v, ok := c.Elems[k].(DurationValue)
@@ -601,7 +605,9 @@ func CopyTimeToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gra
 				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.TimestampList {
 						v, ok := c.Elems[k].(TimeValue)

--- a/examples/tfschema/time/v1/time_terraform.go
+++ b/examples/tfschema/time/v1/time_terraform.go
@@ -300,6 +300,12 @@ func CopyTimeFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 
 // CopyTimeToTerraform copies contents of the source Terraform object into a target struct
 func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Time, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyTimeToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyTimeToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyTimeToTerraformPreserveUnknown(ctx context.Context, obj *github_com_gravitational_protoc_gen_terraform_v3_examples_types.Time, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -328,7 +334,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationCustom)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_custom"] = v
 		}
 	}
@@ -377,12 +385,16 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 						v.Null = false
 						v.Value = time.Duration(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["duration_custom_list"] = c
 			}
 		}
@@ -432,12 +444,16 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 						v.Null = false
 						v.Value = time.Duration(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["duration_list"] = c
 			}
 		}
@@ -464,7 +480,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationStandard)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_standard"] = v
 		}
 	}
@@ -490,7 +508,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 			v.Null = false
 			v.Value = string(obj.Id)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["id"] = v
 		}
 	}
@@ -519,7 +539,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 				v.Null = false
 				v.Value = time.Duration(*obj.NullableDuration)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["nullable_duration"] = v
 		}
 	}
@@ -548,7 +570,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 				v.Null = false
 				v.Value = time.Time(*obj.NullableTimestamp)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["nullable_timestamp"] = v
 		}
 	}
@@ -597,12 +621,16 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 						v.Null = false
 						v.Value = time.Time(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["timestamp_list"] = c
 			}
 		}
@@ -629,7 +657,9 @@ func CopyTimeToTerraform(ctx context.Context, obj *github_com_gravitational_prot
 
 			v.Null = false
 			v.Value = time.Time(obj.TimestampValue)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["timestamp_value"] = v
 		}
 	}

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -17,12 +17,13 @@ func NewMessageCopyToGenerator(m *Message, i *Imports) *MessageCopyToGenerator {
 	return &MessageCopyToGenerator{Message: m, i: i}
 }
 
-// Generate generates CopyToTF<Name> method
+// Generate generates Copy<Name>ToTerraform method.
+// Unknown values are overridden.
 func (m *MessageCopyToGenerator) Generate(writer io.Writer) (int, error) {
 	methodName := "Copy" + m.Name + "ToTerraform"
+	helperName := "Copy" + m.Name + "ToTerraformPreserveUnknown"
 	tf := j.Id("tf").Op("*").Id(m.i.WithPackage(Types, "Object"))
 	obj := j.Id("obj").Op("*").Id(m.i.WithType(m.GoType))
-	diags := j.Var().Id("diags").Id(m.i.WithPackage(Diag, "Diagnostics"))
 	ctx := j.Id("ctx").Id(m.i.WithPackage("context", "Context"))
 
 	// func Copy<name>ToTerraform(ctx context.Context, tf types.Object, obj *apitypes.<name>)
@@ -31,6 +32,33 @@ func (m *MessageCopyToGenerator) Generate(writer io.Writer) (int, error) {
 		j.Commentf("// %v copies contents of the source Terraform object into a target struct\n", methodName).
 			Func().Id(methodName).
 			Params(ctx, obj, tf).
+			Id(m.i.WithPackage(Diag, "Diagnostics")).
+			BlockFunc(func(g *j.Group) {
+				g.Return(j.Id(helperName).Call(j.Id("ctx"), j.Id("obj"), j.Id("tf"), j.False()))
+			})
+
+	return writer.Write([]byte(method.GoString() + "\n"))
+}
+
+// GeneratePreserveUnknown generates Copy<Name>ToTerraformPreserveUnknown method.
+// If the `preserveUnknown` flag is enabled, Unknown values are preserved.
+func (m *MessageCopyToGenerator) GeneratePreserveUnknown(writer io.Writer) (int, error) {
+	methodName := "Copy" + m.Name + "ToTerraformPreserveUnknown"
+	tf := j.Id("tf").Op("*").Id(m.i.WithPackage(Types, "Object"))
+	obj := j.Id("obj").Op("*").Id(m.i.WithType(m.GoType))
+	diags := j.Var().Id("diags").Id(m.i.WithPackage(Diag, "Diagnostics"))
+	ctx := j.Id("ctx").Id(m.i.WithPackage("context", "Context"))
+	preserveUnknown := j.Id("preserveUnknown").Id("bool")
+	comment := "// %v copies contents of the source Terraform object into a target struct.\n" +
+		"// Set preserveUnknown to true to preserve unknown values.\n"
+
+	// func Copy<name>ToTerraformPreserveUnknown(ctx context.Context, tf types.Object, obj *apitypes.<name>, preserveUnknown bool)
+	// ... statements for a fields
+
+	method :=
+		j.Commentf(comment, methodName).
+			Func().Id(methodName).
+			Params(ctx, obj, tf, preserveUnknown).
 			Id(m.i.WithPackage(Diag, "Diagnostics")).
 			BlockFunc(func(g *j.Group) {
 				g.Add(diags)
@@ -174,7 +202,9 @@ func (f *FieldCopyToGenerator) genPrimitiveBody(g *j.Group, fieldName string) {
 	g.Add(f.genAssignValue(fieldName))
 
 	// Set `Unknown = false` for all values
-	g.Id("v.Unknown").Op("=").False()
+	g.If(j.Id("!preserveUnknown")).Block(
+		j.Id("v.Unknown").Op("=").False(),
+	)
 }
 
 func (f *FieldCopyToGenerator) genAssignValue(fieldName string) *j.Statement {
@@ -311,7 +341,10 @@ func (f *FieldCopyToGenerator) genObjectBody(g *j.Group, m *MessageCopyToGenerat
 	} else {
 		g.BlockFunc(copyObj)
 	}
-	g.Id("v.Unknown").Op("=").False()
+
+	g.If(j.Id("!preserveUnknown")).Block(
+		j.Id("v.Unknown").Op("=").False(),
+	)
 }
 
 // assertTo asserts a to typ
@@ -440,7 +473,11 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 
 			// List and Map attributes are normalized to an empty value
 			g.Id("c.Null").Op("=").False()
-			g.Id("c.Unknown").Op("=").False()
+
+			g.If(j.Id("!preserveUnknown")).Block(
+				j.Id("c.Unknown").Op("=").False(),
+			)
+
 			g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("c")
 		})
 	})

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -450,7 +450,9 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 					// This check creates a new array if that's the case.
 					// Otherwise, we would have a panic at the last line in the For loop or extra elements.
 					g.If(j.Len(j.Id(fieldName)).Op("!=").Len(j.Id("c.Elems"))).Block(
-						j.Id("c.Elems").Op("=").Add(mk),
+						j.Id("newElems").Op(":=").Add(mk),
+						j.Id("copy").Call(j.Id("newElems"), j.Id("c.Elems")),
+						j.Id("c.Elems").Op("=").Add(j.Id("newElems")),
 					)
 				}
 

--- a/plugin.go
+++ b/plugin.go
@@ -156,6 +156,10 @@ func (p *Plugin) write(m []*Message, out io.Writer) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		_, err = t.GeneratePreserveUnknown(out)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	_, err := NewSharedCodeGenerator(&p.Imports).Write(out)

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -376,3 +376,71 @@ func TestCopyToNestedNullableWithNullTerraformObject(t *testing.T) {
 		nestedNullable.Attrs["str"].(types.String),
 	)
 }
+
+func TestCopyToTerraformPreserveUnknown(t *testing.T) {
+	o := copyToTerraformObject(t)
+	o.Attrs["str"] = types.String{Unknown: true, Value: "stale"}
+
+	diags := CopyTestToTerraformPreserveUnknown(context.Background(), createTestObj(), &o, true)
+	requireNoDiagErrors(t, diags)
+
+	v := o.Attrs["str"].(types.String)
+	require.True(t, v.Unknown)
+	require.False(t, v.Null)
+	require.Equal(t, "TestString", v.Value)
+}
+
+func TestCopyToTerraformPreserveUnknownNested(t *testing.T) {
+	o := copyToTerraformObject(t)
+
+	nestedType, ok := o.AttrTypes["nested"].(types.ObjectType)
+	require.True(t, ok)
+
+	nestedListType, ok := nestedType.AttrTypes["nested_list"].(types.ListType)
+	require.True(t, ok)
+
+	o.Attrs["nested"] = types.Object{
+		Unknown:   true,
+		AttrTypes: nestedType.AttrTypes,
+		Attrs: map[string]attr.Value{
+			"str": types.String{Unknown: true, Value: "stale"},
+			"nested_list": types.List{
+				Unknown:  true,
+				ElemType: nestedListType.ElemType,
+				Elems: []attr.Value{
+					types.Object{
+						Unknown:   true,
+						AttrTypes: nestedListType.ElemType.(types.ObjectType).AttrTypes,
+						Attrs: map[string]attr.Value{
+							"str": types.String{Unknown: true, Value: "stale"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diags := CopyTestToTerraformPreserveUnknown(context.Background(), createTestObj(), &o, true)
+	requireNoDiagErrors(t, diags)
+
+	nested := o.Attrs["nested"].(types.Object)
+	require.True(t, nested.Unknown)
+
+	str := nested.Attrs["str"].(types.String)
+	require.True(t, str.Unknown)
+	require.Equal(t, "TestString", str.Value)
+
+	nestedList := nested.Attrs["nested_list"].(types.List)
+	require.True(t, nestedList.Unknown)
+	require.Len(t, nestedList.Elems, 2)
+
+	firstElem := nestedList.Elems[0].(types.Object)
+	require.True(t, firstElem.Unknown)
+	require.Equal(t, "Test1", firstElem.Attrs["str"].(types.String).Value)
+	require.True(t, firstElem.Attrs["str"].(types.String).Unknown)
+
+	secondElem := nestedList.Elems[1].(types.Object)
+	require.False(t, secondElem.Unknown)
+	require.Equal(t, "Test2", secondElem.Attrs["str"].(types.String).Value)
+	require.False(t, secondElem.Attrs["str"].(types.String).Unknown)
+}

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -60,6 +60,10 @@ func createTestObj() *Test {
 
 		Nested: Nested{
 			Str: "TestString",
+			NestedList: []*OtherNested{
+				{Str: "Test1"},
+				{Str: "Test2"},
+			},
 		},
 		NestedNullable: &Nested{
 			Str: "TestString",
@@ -70,10 +74,10 @@ func createTestObj() *Test {
 			{
 				Str: "Test",
 				NestedList: []*OtherNested{
-					&OtherNested{
+					{
 						Str: "Test1",
 					},
-					&OtherNested{
+					{
 						Str: "Test2",
 					},
 				},

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -601,7 +601,9 @@ func CopyOptionalTestToTerraformPreserveUnknown(ctx context.Context, obj *Option
 				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.StringList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -281,6 +281,12 @@ func CopyOptionalTestFromTerraform(_ context.Context, tf github_com_hashicorp_te
 
 // CopyOptionalTestToTerraform copies contents of the source Terraform object into a target struct
 func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyOptionalTestToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyOptionalTestToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyOptionalTestToTerraformPreserveUnknown(ctx context.Context, obj *OptionalTest, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -315,7 +321,9 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 					v.Value = string(obj.ChoiceA)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["choice_a"] = v
 		}
 	}
@@ -347,7 +355,9 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 					v.Value = string(obj.ChoiceB)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["choice_b"] = v
 		}
 	}
@@ -376,7 +386,9 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 				v.Null = false
 				v.Value = bool(*obj.OptionalBool)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["optional_bool"] = v
 		}
 	}
@@ -432,12 +444,16 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 								v.Null = false
 								v.Value = bool(*obj.InnerBool)
 							}
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["inner_bool"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["optional_inner_message"] = v
 			}
 		}
@@ -467,7 +483,9 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 				v.Null = false
 				v.Value = int64(*obj.OptionalInt64)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["optional_int64"] = v
 		}
 	}
@@ -513,12 +531,16 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["optional_map"] = c
 			}
 		}
@@ -548,7 +570,9 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 				v.Null = false
 				v.Value = string(*obj.OptionalStr)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["optional_str"] = v
 		}
 	}
@@ -597,12 +621,16 @@ func CopyOptionalTestToTerraform(ctx context.Context, obj *OptionalTest, tf *git
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["string_list"] = c
 			}
 		}

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2489,6 +2489,12 @@ func CopyTestFromTerraform(_ context.Context, tf github_com_hashicorp_terraform_
 
 // CopyTestToTerraform copies contents of the source Terraform object into a target struct
 func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicorp_terraform_plugin_framework_types.Object) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
+	return CopyTestToTerraformPreserveUnknown(ctx, obj, tf, false)
+}
+
+// CopyTestToTerraformPreserveUnknown copies contents of the source Terraform object into a target struct.
+// Set preserveUnknown to true to preserve unknown values.
+func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *github_com_hashicorp_terraform_plugin_framework_types.Object, preserveUnknown bool) github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics {
 	var diags github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics
 	tf.Null = false
 	tf.Unknown = false
@@ -2523,7 +2529,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					v.Value = string(obj.Bar)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["bar"] = v
 		}
 	}
@@ -2549,7 +2557,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = bool(obj.Bool)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["bool"] = v
 		}
 	}
@@ -2615,12 +2625,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = string(obj.Str)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["str"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["branch1"] = v
 			}
 		}
@@ -2678,12 +2692,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = int64(obj.Int32)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["int32"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["branch2"] = v
 			}
 		}
@@ -2716,7 +2734,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					v.Value = string(obj.Branch3)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["branch3"] = v
 		}
 	}
@@ -2742,7 +2762,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = string(obj.Bytes)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["bytes"] = v
 		}
 	}
@@ -2791,12 +2813,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["bytes_list"] = c
 			}
 		}
@@ -2823,7 +2849,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = float64(obj.Double)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["double"] = v
 		}
 	}
@@ -2849,7 +2877,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationCustom)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_custom"] = v
 		}
 	}
@@ -2898,12 +2928,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 						v.Null = false
 						v.Value = time.Duration(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["duration_custom_list"] = c
 			}
 		}
@@ -2930,7 +2964,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationCustomMissing)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_custom_missing"] = v
 		}
 	}
@@ -2956,7 +2992,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationStandard)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_standard"] = v
 		}
 	}
@@ -2982,7 +3020,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Duration(obj.DurationStandardMissing)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["duration_standard_missing"] = v
 		}
 	}
@@ -3035,12 +3075,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = string(obj.EmbeddedNestedString)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["embedded_nested_string"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["embedded_nested_field"] = v
 			}
 		}
@@ -3067,7 +3111,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = string(obj.EmbeddedString)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["embedded_string"] = v
 		}
 	}
@@ -3121,12 +3167,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 								}
 							}
 							v.Null = true
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["active"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["empty_message_branch"] = v
 			}
 		}
@@ -3153,7 +3203,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = float64(obj.Float)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["float"] = v
 		}
 	}
@@ -3185,7 +3237,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					v.Value = string(obj.Foo)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["foo"] = v
 		}
 	}
@@ -3211,7 +3265,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = int64(obj.Int32)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["int32"] = v
 		}
 	}
@@ -3237,7 +3293,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = int64(obj.Int64)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["int64"] = v
 		}
 	}
@@ -3283,12 +3341,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["map"] = c
 			}
 		}
@@ -3376,12 +3438,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 												v.Null = false
 												v.Value = string(a)
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map"] = c
 									}
 								}
@@ -3449,17 +3515,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map_object_nested"] = c
 									}
 								}
@@ -3532,17 +3604,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["nested_list"] = c
 									}
 								}
@@ -3569,17 +3647,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 									v.Null = false
 									v.Value = string(obj.Str)
-									v.Unknown = false
+									if !preserveUnknown {
+										v.Unknown = false
+									}
 									tf.Attrs["str"] = v
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["map_object"] = c
 			}
 		}
@@ -3669,12 +3753,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 												v.Null = false
 												v.Value = string(a)
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map"] = c
 									}
 								}
@@ -3742,17 +3830,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map_object_nested"] = c
 									}
 								}
@@ -3825,17 +3919,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["nested_list"] = c
 									}
 								}
@@ -3862,17 +3962,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 									v.Null = false
 									v.Value = string(obj.Str)
-									v.Unknown = false
+									if !preserveUnknown {
+										v.Unknown = false
+									}
 									tf.Attrs["str"] = v
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["map_object_nullable"] = c
 			}
 		}
@@ -3899,7 +4005,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = int64(obj.Mode)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["mode"] = v
 		}
 	}
@@ -3970,12 +4078,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map"] = c
 							}
 						}
@@ -4043,17 +4155,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map_object_nested"] = c
 							}
 						}
@@ -4126,17 +4244,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["nested_list"] = c
 							}
 						}
@@ -4163,12 +4287,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = string(obj.Str)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["str"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["nested"] = v
 			}
 		}
@@ -4259,12 +4387,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 												v.Null = false
 												v.Value = string(a)
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map"] = c
 									}
 								}
@@ -4332,17 +4464,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map_object_nested"] = c
 									}
 								}
@@ -4415,17 +4553,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["nested_list"] = c
 									}
 								}
@@ -4452,17 +4596,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 									v.Null = false
 									v.Value = string(obj.Str)
-									v.Unknown = false
+									if !preserveUnknown {
+										v.Unknown = false
+									}
 									tf.Attrs["str"] = v
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_list"] = c
 			}
 		}
@@ -4555,12 +4705,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 												v.Null = false
 												v.Value = string(a)
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map"] = c
 									}
 								}
@@ -4628,17 +4782,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["map_object_nested"] = c
 									}
 								}
@@ -4711,17 +4871,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 															v.Null = false
 															v.Value = string(obj.Str)
-															v.Unknown = false
+															if !preserveUnknown {
+																v.Unknown = false
+															}
 															tf.Attrs["str"] = v
 														}
 													}
 												}
-												v.Unknown = false
+												if !preserveUnknown {
+													v.Unknown = false
+												}
 												c.Elems[k] = v
 											}
 										}
 										c.Null = false
-										c.Unknown = false
+										if !preserveUnknown {
+											c.Unknown = false
+										}
 										tf.Attrs["nested_list"] = c
 									}
 								}
@@ -4748,17 +4914,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 									v.Null = false
 									v.Value = string(obj.Str)
-									v.Unknown = false
+									if !preserveUnknown {
+										v.Unknown = false
+									}
 									tf.Attrs["str"] = v
 								}
 							}
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["nested_list_nullable"] = c
 			}
 		}
@@ -4832,12 +5004,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map"] = c
 							}
 						}
@@ -4905,17 +5081,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map_object_nested"] = c
 							}
 						}
@@ -4988,17 +5170,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["nested_list"] = c
 							}
 						}
@@ -5025,12 +5213,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = string(obj.Str)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["str"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["nested_nullable"] = v
 			}
 		}
@@ -5104,12 +5296,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 										v.Null = false
 										v.Value = string(a)
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map"] = c
 							}
 						}
@@ -5177,17 +5373,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["map_object_nested"] = c
 							}
 						}
@@ -5260,17 +5462,23 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 													v.Null = false
 													v.Value = string(obj.Str)
-													v.Unknown = false
+													if !preserveUnknown {
+														v.Unknown = false
+													}
 													tf.Attrs["str"] = v
 												}
 											}
 										}
-										v.Unknown = false
+										if !preserveUnknown {
+											v.Unknown = false
+										}
 										c.Elems[k] = v
 									}
 								}
 								c.Null = false
-								c.Unknown = false
+								if !preserveUnknown {
+									c.Unknown = false
+								}
 								tf.Attrs["nested_list"] = c
 							}
 						}
@@ -5297,12 +5505,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 							v.Null = false
 							v.Value = string(obj.Str)
-							v.Unknown = false
+							if !preserveUnknown {
+								v.Unknown = false
+							}
 							tf.Attrs["str"] = v
 						}
 					}
 				}
-				v.Unknown = false
+				if !preserveUnknown {
+					v.Unknown = false
+				}
 				tf.Attrs["nested_nullable_with_nil_value"] = v
 			}
 		}
@@ -5329,7 +5541,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = string(obj.RequiredStr)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["required_str"] = v
 		}
 	}
@@ -5355,7 +5569,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = string(obj.SchemaOverride)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["schema_override"] = v
 		}
 	}
@@ -5381,7 +5597,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = string(obj.Str)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["str"] = v
 		}
 	}
@@ -5413,7 +5631,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 					v.Value = string(obj.StringBranch)
 				}
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["string_branch"] = v
 		}
 	}
@@ -5462,12 +5682,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["string_list"] = c
 			}
 		}
@@ -5517,12 +5741,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 						v.Null = false
 						v.Value = string(a)
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["string_list_empty"] = c
 			}
 		}
@@ -5558,7 +5786,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Time(obj.Timestamp)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["timestamp"] = v
 		}
 	}
@@ -5610,12 +5840,16 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 							v.Null = false
 							v.Value = time.Time(*a)
 						}
-						v.Unknown = false
+						if !preserveUnknown {
+							v.Unknown = false
+						}
 						c.Elems[k] = v
 					}
 				}
 				c.Null = false
-				c.Unknown = false
+				if !preserveUnknown {
+					c.Unknown = false
+				}
 				tf.Attrs["timestamp_list"] = c
 			}
 		}
@@ -5642,7 +5876,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 
 			v.Null = false
 			v.Value = time.Time(obj.TimestampMissing)
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["timestamp_missing"] = v
 		}
 	}
@@ -5671,7 +5907,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				v.Null = false
 				v.Value = time.Time(*obj.TimestampNullable)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["timestamp_nullable"] = v
 		}
 	}
@@ -5700,7 +5938,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				v.Null = false
 				v.Value = time.Time(*obj.TimestampNullableWithNilValue)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["timestamp_nullable_with_nil_value"] = v
 		}
 	}
@@ -5729,7 +5969,9 @@ func CopyTestToTerraform(ctx context.Context, obj *Test, tf *github_com_hashicor
 				v.Null = false
 				v.Value = time.Duration(obj.Value)
 			}
-			v.Unknown = false
+			if !preserveUnknown {
+				v.Unknown = false
+			}
 			tf.Attrs["max_age"] = v
 		}
 	}

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2793,7 +2793,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					t := o.ElemType
 					if len(obj.BytesList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.BytesList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.BytesList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -2908,7 +2910,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					t := o.ElemType
 					if len(obj.DurationCustomList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.DurationCustomList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.DurationCustomList {
 						v, ok := c.Elems[k].(DurationValue)
@@ -3561,7 +3565,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
-												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												copy(newElems, c.Elems)
+												c.Elems = newElems
 											}
 											for k, a := range obj.NestedList {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -3876,7 +3882,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
-												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												copy(newElems, c.Elems)
+												c.Elems = newElems
 											}
 											for k, a := range obj.NestedList {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4201,7 +4209,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.NestedList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4326,7 +4336,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.NestedList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4510,7 +4522,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
-												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												copy(newElems, c.Elems)
+												c.Elems = newElems
 											}
 											for k, a := range obj.NestedList {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4642,7 +4656,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 					if len(obj.NestedListNullable) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedListNullable))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.NestedListNullable {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -4828,7 +4844,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 										{
 											o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 											if len(obj.NestedList) != len(c.Elems) {
-												c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+												copy(newElems, c.Elems)
+												c.Elems = newElems
 											}
 											for k, a := range obj.NestedList {
 												v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -5127,7 +5145,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.NestedList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -5419,7 +5439,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 								{
 									o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
 									if len(obj.NestedList) != len(c.Elems) {
-										c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.NestedList))
+										copy(newElems, c.Elems)
+										c.Elems = newElems
 									}
 									for k, a := range obj.NestedList {
 										v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.Object)
@@ -5662,7 +5684,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					t := o.ElemType
 					if len(obj.StringList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.StringList {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -5721,7 +5745,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					t := o.ElemType
 					if len(obj.StringListEmpty) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.StringListEmpty))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.StringListEmpty {
 						v, ok := c.Elems[k].(github_com_hashicorp_terraform_plugin_framework_types.String)
@@ -5817,7 +5843,9 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 				{
 					t := o.ElemType
 					if len(obj.TimestampList) != len(c.Elems) {
-						c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
+						newElems := make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.TimestampList))
+						copy(newElems, c.Elems)
+						c.Elems = newElems
 					}
 					for k, a := range obj.TimestampList {
 						v, ok := c.Elems[k].(TimeValue)


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397

While working on upgrading `protoc-gen-terraform` to v4 within teleport, we implemented a resource-level `ModifyPlan` function that is responsible for reading TF config values and normalizing `null` and `unknown` values to default/zero values accordingly (https://github.com/gravitational/teleport/pull/67294).

This works fine when the `unknown` values are expected to be computed by Teleport because `CheckAndSetDefaults` will be used to set the values that would be expected after apply.

However, there are other valid apply-time `unknown` values that can be used that would differ from the expected default values, and in these cases `CheckAndSetDefaults` would set an incorrect planned value. This could happen if a value is a reference to another `unknown` value, for example a `random.random_integer`.

To resolve the issue, this PR proposes a change to the generated `ToTerraform` function. The function now accepts a `preserveUnknown` flag that, when true, preserves unknown values. Along with this change, the resource templates in teleport `plural_resource.go.tpl` and `singular_resource.go.tpl` will need to be updated to preserve unknown values during `ModifyPlan`.

### Example
Here is an example using the `random` provider.
<details>
<summary>Example</summary>

If we use the `random` provider to generate an apply-time random value for `priority` we can run into `Provider produced invalid plan` error.

First, create a `teleport_login_rule`
```hcl
resource "teleport_login_rule" "test" {
  metadata = {
    name = "unknown-priority"
  }

  version           = "v1"
  priority          = 7
  traits_expression = "external"
}
```

Then update the `priority` with a random value.
```hcl
provider "random" {}

resource "random_integer" "prio" {
  min = 1
  max = 50

  keepers = {
    nonce = timestamp()
  }
}

resource "teleport_login_rule" "test" {
  metadata = {
    name = "unknown-priority"
  }

  version           = "v1"
  priority          = random_integer.prio.result
  traits_expression = "external"
}
```

When running `terraform plan`, we see that the `0` value is planned for `priority` when `unknown` is the expected value.
```hcl
❯ terraform plan
teleport_login_rule.test: Refreshing state... [id=unknown-priority]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform planned the following actions, but then encountered a problem:

  # random_integer.prio will be created
  + resource "random_integer" "prio" {
      + id      = (known after apply)
      + keepers = {
          + "nonce" = (known after apply)
        }
      + max     = 50
      + min     = 1
      + result  = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Error: Provider produced invalid plan
│
│ Provider "terraform.releases.teleport.dev/gravitational/teleport" planned an invalid value for teleport_login_rule.test.priority: planned value
│ cty.NumberIntVal(0) does not match config value cty.UnknownVal(cty.Number) nor prior value cty.NumberIntVal(7).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

</details>



