### PR TITLE
Preserve Unknown values in custom types

### DIFF
--- a/examples/testlib/custom_test.go
+++ b/examples/testlib/custom_test.go
@@ -60,7 +60,7 @@ func (s *TerraformSuite) TestCustomNullValues() {
 					resource.TestCheckResourceAttr(name, "bool_custom", "false"),
 					resource.TestCheckNoResourceAttr(name, "bool_custom_list.0"),
 
-					resource.TestCheckNoResourceAttr(name, "string_override.0"),
+					resource.TestCheckResourceAttr(name, "string_override.0", ""),
 					resource.TestCheckResourceAttr(name, "schema_override", ""),
 				),
 			},

--- a/examples/tfschema/custom/v1/custom_terraform.go
+++ b/examples/tfschema/custom/v1/custom_terraform.go
@@ -307,7 +307,7 @@ func CopyCustomToTerraformPreserveUnknown(ctx context.Context, obj *github_com_g
 		if !ok {
 			diags.Append(attrWriteMissingDiag{"Custom.bool_custom"})
 		} else {
-			v := CopyToBoolSpecial(diags, obj.BoolCustom, t, tf.Attrs["bool_custom"])
+			v := CopyToBoolSpecial(diags, obj.BoolCustom, t, tf.Attrs["bool_custom"], preserveUnknown)
 			tf.Attrs["bool_custom"] = v
 		}
 	}
@@ -316,7 +316,7 @@ func CopyCustomToTerraformPreserveUnknown(ctx context.Context, obj *github_com_g
 		if !ok {
 			diags.Append(attrWriteMissingDiag{"Custom.bool_custom_list"})
 		} else {
-			v := CopyToBoolSpecialList(diags, obj.BoolCustomList, t, tf.Attrs["bool_custom_list"])
+			v := CopyToBoolSpecialList(diags, obj.BoolCustomList, t, tf.Attrs["bool_custom_list"], preserveUnknown)
 			tf.Attrs["bool_custom_list"] = v
 		}
 	}
@@ -521,7 +521,7 @@ func CopyCustomToTerraformPreserveUnknown(ctx context.Context, obj *github_com_g
 		if !ok {
 			diags.Append(attrWriteMissingDiag{"Custom.string_override"})
 		} else {
-			v := CopyToStringCustom(diags, obj.StringOverride, t, tf.Attrs["string_override"])
+			v := CopyToStringCustom(diags, obj.StringOverride, t, tf.Attrs["string_override"], preserveUnknown)
 			tf.Attrs["string_override"] = v
 		}
 	}

--- a/examples/types/custom_types.go
+++ b/examples/types/custom_types.go
@@ -43,8 +43,18 @@ func CopyFromBoolSpecial(diags diag.Diagnostics, tf attr.Value, obj *BoolCustom)
 }
 
 // CopyToBoolSpecial copies source value to the target
-func CopyToBoolSpecial(diags diag.Diagnostics, obj BoolCustom, t attr.Type, v attr.Value) attr.Value {
-	return types.Bool{Value: bool(obj)}
+func CopyToBoolSpecial(diags diag.Diagnostics, obj BoolCustom, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
+	unknown := false
+	if v != nil {
+		unknown = preserveUnknown && v.IsUnknown()
+	}
+
+	value := types.Bool{
+		Value:   bool(obj),
+		Unknown: unknown,
+	}
+
+	return value
 }
 
 type BoolCustomList bool
@@ -82,7 +92,7 @@ func CopyFromBoolSpecialList(diags diag.Diagnostics, tf attr.Value, obj *[]BoolC
 }
 
 // CopyToBoolSpecialList copies source value to the target
-func CopyToBoolSpecialList(diags diag.Diagnostics, obj []BoolCustomList, t attr.Type, v attr.Value) attr.Value {
+func CopyToBoolSpecialList(diags diag.Diagnostics, obj []BoolCustomList, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	value, ok := v.(types.List)
 	if !ok {
 		value = types.List{
@@ -90,15 +100,23 @@ func CopyToBoolSpecialList(diags diag.Diagnostics, obj []BoolCustomList, t attr.
 			ElemType: types.BoolType,
 		}
 	}
-	value.Unknown = false
+	value.Unknown = preserveUnknown && value.IsUnknown()
 
-	if len(obj) > 0 {
-		if value.Elems == nil {
-			value.Elems = make([]attr.Value, len(obj))
+	if len(value.Elems) != len(obj) {
+		newElems := make([]attr.Value, len(obj))
+		copy(newElems, value.Elems)
+		value.Elems = newElems
+	}
+
+	for i, b := range obj {
+		elemUnknown := false
+		if value.Elems[i] != nil {
+			elemUnknown = preserveUnknown && value.Elems[i].IsUnknown()
 		}
 
-		for i, b := range obj {
-			value.Elems[i] = types.Bool{Null: false, Unknown: false, Value: bool(b)}
+		value.Elems[i] = types.Bool{
+			Value:   bool(b),
+			Unknown: elemUnknown,
 		}
 	}
 
@@ -143,7 +161,7 @@ func CopyFromStringCustom(diags diag.Diagnostics, tf attr.Value, obj *string) {
 
 // CopyToStringCustom copies a source value (single string) into the Terraform
 // value (a list of strings) by splitting the string on every "/".
-func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.Value) attr.Value {
+func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	value, ok := v.(types.List)
 	if !ok {
 		value = types.List{
@@ -151,15 +169,24 @@ func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.
 			ElemType: types.StringType,
 		}
 	}
-	value.Unknown = false
+	value.Unknown = preserveUnknown && value.IsUnknown()
 
-	if len(obj) > 0 {
-		if value.Elems == nil {
-			value.Elems = make([]attr.Value, len(obj))
+	parts := strings.Split(obj, "/")
+	if len(value.Elems) != len(parts) {
+		newElems := make([]attr.Value, len(parts))
+		copy(newElems, value.Elems)
+		value.Elems = newElems
+	}
+
+	for i, b := range parts {
+		elemUnknown := false
+		if value.Elems[i] != nil {
+			elemUnknown = preserveUnknown && value.Elems[i].IsUnknown()
 		}
 
-		for i, b := range strings.Split(obj, "/") {
-			value.Elems[i] = types.String{Null: false, Unknown: false, Value: b}
+		value.Elems[i] = types.String{
+			Value:   b,
+			Unknown: elemUnknown,
 		}
 	}
 

--- a/examples/types/custom_types_test.go
+++ b/examples/types/custom_types_test.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyToBoolSpecialPreserveUnknownWithNil(t *testing.T) {
+	var diags diag.Diagnostics
+
+	result := CopyToBoolSpecial(diags, BoolCustom(true), types.BoolType, nil, true)
+
+	boolValue, ok := result.(types.Bool)
+	require.True(t, ok)
+	require.Equal(t, types.Bool{
+		Null:    false,
+		Unknown: false,
+		Value:   true,
+	}, boolValue)
+}
+
+func TestCopyToBoolSpecialPreserveUnknown(t *testing.T) {
+	var diags diag.Diagnostics
+
+	val := types.Bool{Unknown: true, Value: false}
+	result := CopyToBoolSpecial(diags, BoolCustom(true), types.BoolType, val, true)
+
+	boolValue, ok := result.(types.Bool)
+	require.True(t, ok)
+	require.Equal(t, types.Bool{
+		Null:    false,
+		Unknown: true,
+		Value:   true,
+	}, boolValue)
+}
+
+func TestCopyToBoolSpecialListPreserveUnknownWithEmptySlice(t *testing.T) {
+	var diags diag.Diagnostics
+
+	val := types.List{
+		Unknown:  true,
+		Elems:    []attr.Value{},
+		ElemType: types.BoolType,
+	}
+	result := CopyToBoolSpecialList(diags, []BoolCustomList{true}, types.ListType{ElemType: types.BoolType}, val, true)
+
+	listValue, ok := result.(types.List)
+	require.True(t, ok)
+	require.Equal(t, types.List{
+		Null:     false,
+		Unknown:  true,
+		Elems:    []attr.Value{types.Bool{Null: false, Unknown: false, Value: true}},
+		ElemType: types.BoolType,
+	}, listValue)
+}

--- a/gen_copy_to.go
+++ b/gen_copy_to.go
@@ -489,7 +489,7 @@ func (f *FieldCopyToGenerator) genListOrMap() *j.Statement {
 func (f *FieldCopyToGenerator) genCustom() *j.Statement {
 	return f.nextField("t", func(g *j.Group) {
 		g.Id("v").Op(":=").Id("CopyTo"+f.Suffix).Params(
-			j.Id("diags"), j.Id("obj."+f.Name), j.Id("t"), j.Id("tf.Attrs").Index(j.Lit(f.NameSnake)),
+			j.Id("diags"), j.Id("obj."+f.Name), j.Id("t"), j.Id("tf.Attrs").Index(j.Lit(f.NameSnake)), j.Id("preserveUnknown"),
 		)
 		g.Id("tf.Attrs").Index(j.Lit(f.NameSnake)).Op("=").Id("v")
 	})

--- a/test/copy_to_terraform_test.go
+++ b/test/copy_to_terraform_test.go
@@ -444,3 +444,31 @@ func TestCopyToTerraformPreserveUnknownNested(t *testing.T) {
 	require.Equal(t, "Test2", secondElem.Attrs["str"].(types.String).Value)
 	require.False(t, secondElem.Attrs["str"].(types.String).Unknown)
 }
+
+func TestCopyToCustomPreserveUnknown(t *testing.T) {
+	o := copyToTerraformObject(t)
+	o.Attrs["bool_custom_list"] = types.List{
+		Unknown: true,
+		Elems: []attr.Value{
+			types.Bool{Unknown: false, Value: false},
+			types.Bool{Unknown: true, Value: false},
+			types.Bool{Unknown: true, Value: true},
+		},
+		ElemType: types.BoolType,
+	}
+
+	diags := CopyTestToTerraformPreserveUnknown(context.Background(), createTestObj(), &o, true)
+	requireNoDiagErrors(t, diags)
+
+	v := o.Attrs["bool_custom_list"].(types.List)
+
+	require.True(t, v.IsUnknown())
+	require.Equal(t,
+		[]attr.Value{
+			types.Bool{Null: false, Unknown: false, Value: false},
+			types.Bool{Null: false, Unknown: true, Value: false},
+			types.Bool{Null: false, Unknown: true, Value: true},
+		},
+		v.Elems,
+	)
+}

--- a/test/custom_types.go
+++ b/test/custom_types.go
@@ -59,23 +59,31 @@ func CopyFromBoolSpecial(diags diag.Diagnostics, tf attr.Value, obj *[]BoolCusto
 }
 
 // CopyToBoolSpecial copies source value to the target
-func CopyToBoolSpecial(diags diag.Diagnostics, obj []BoolCustom, t attr.Type, v attr.Value) attr.Value {
+func CopyToBoolSpecial(diags diag.Diagnostics, obj []BoolCustom, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	value, ok := v.(types.List)
 	if !ok {
 		value = types.List{
 			Null:     true,
-			Unknown:  false,
 			ElemType: types.BoolType,
 		}
 	}
+	value.Unknown = preserveUnknown && value.IsUnknown()
 
-	if len(obj) > 0 {
-		if value.Elems == nil {
-			value.Elems = make([]attr.Value, len(obj))
+	if len(value.Elems) != len(obj) {
+		newElems := make([]attr.Value, len(obj))
+		copy(newElems, value.Elems)
+		value.Elems = newElems
+	}
+
+	for i, b := range obj {
+		elemUnknown := false
+		if value.Elems[i] != nil {
+			elemUnknown = preserveUnknown && value.Elems[i].IsUnknown()
 		}
 
-		for i, b := range obj {
-			value.Elems[i] = types.Bool{Null: false, Unknown: false, Value: bool(b)}
+		value.Elems[i] = types.Bool{
+			Value:   bool(b),
+			Unknown: elemUnknown,
 		}
 	}
 
@@ -121,7 +129,7 @@ func CopyFromStringCustom(diags diag.Diagnostics, tf attr.Value, obj *string) {
 
 // CopyToStringCustom copies a source value (single string) into the Terraform
 // value (a list of strings) by splitting the string on every "/".
-func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.Value) attr.Value {
+func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value {
 	value, ok := v.(types.List)
 	if !ok {
 		value = types.List{
@@ -130,14 +138,24 @@ func CopyToStringCustom(diags diag.Diagnostics, obj string, t attr.Type, v attr.
 			ElemType: types.StringType,
 		}
 	}
+	value.Unknown = preserveUnknown && value.IsUnknown()
 
-	if len(obj) > 0 {
-		if value.Elems == nil {
-			value.Elems = make([]attr.Value, len(obj))
+	parts := strings.Split(obj, "/")
+	if len(value.Elems) != len(parts) {
+		newElems := make([]attr.Value, len(parts))
+		copy(newElems, value.Elems)
+		value.Elems = newElems
+	}
+
+	for i, b := range parts {
+		elemUnknown := false
+		if value.Elems[i] != nil {
+			elemUnknown = preserveUnknown && value.Elems[i].IsUnknown()
 		}
 
-		for i, b := range strings.Split(obj, "/") {
-			value.Elems[i] = types.String{Null: false, Unknown: false, Value: b}
+		value.Elems[i] = types.String{
+			Value:   b,
+			Unknown: elemUnknown,
 		}
 	}
 

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -2568,7 +2568,7 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 		if !ok {
 			diags.Append(attrWriteMissingDiag{"Test.BoolCustomList"})
 		} else {
-			v := CopyToBoolSpecial(diags, obj.BoolCustomList, t, tf.Attrs["bool_custom_list"])
+			v := CopyToBoolSpecial(diags, obj.BoolCustomList, t, tf.Attrs["bool_custom_list"], preserveUnknown)
 			tf.Attrs["bool_custom_list"] = v
 		}
 	}
@@ -5786,7 +5786,7 @@ func CopyTestToTerraformPreserveUnknown(ctx context.Context, obj *Test, tf *gith
 		if !ok {
 			diags.Append(attrWriteMissingDiag{"Test.StringOverride"})
 		} else {
-			v := CopyToStringCustom(diags, obj.StringOverride, t, tf.Attrs["string_override"])
+			v := CopyToStringCustom(diags, obj.StringOverride, t, tf.Attrs["string_override"], preserveUnknown)
 			tf.Attrs["string_override"] = v
 		}
 	}


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/pull/8397

This is a follow up to https://github.com/gravitational/protoc-gen-terraform/pull/77 and passes the `preserveUnknown` flag to custom `CopyTo` functions. The relevant change is a single line change in `gen_copy_to.go` while the other changes are updates to tests and examples.

### User-facing changes
Custom type `CopyTo*` method signature

Before:
```go
CopyToBoolSpecial(diags diag.Diagnostics, obj BoolCustom, t attr.Type, v attr.Value) attr.Value 
```

After:
```go
CopyToBoolSpecial(diags diag.Diagnostics, obj BoolCustom, t attr.Type, v attr.Value, preserveUnknown bool) attr.Value 
```


### Example

Here is an example of the issue using the `random` provider.

<details>

If we try to create a role `teleport_role` with unknown value for `spec.allow.node_labels` we get a `invalid plan` error. This is the same type of error seen in #77. 

```sh
❯ cat role.tf
resource "random_id" "rid" {
  byte_length = 8
}

resource "teleport_role" "test" {
  version = "v8"
  metadata = {
    name = "example"
  }

  spec = {
    allow = {
      logins = [random_id.rid.id]
      node_labels = {
        env = [random_id.rid.id]
      }
    }
  }
}
```

```sh
❯ terraform plan
random_id.rid: Refreshing state... [id=y8etqi0O]
teleport_role.test: Refreshing state... [id=example]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform planned the following actions, but then encountered a problem:

  # random_id.rid must be replaced
-/+ resource "random_id" "rid" {
      ~ b64_std     = "y8etqi0O" -> (known after apply)
      ~ b64_url     = "y8etqi0O" -> (known after apply)
      ~ byte_length = 6 -> 8 # forces replacement
      ~ dec         = "224058472541454" -> (known after apply)
      ~ hex         = "cbc7adaa2d0e" -> (known after apply)
      ~ id          = "y8etqi0O" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
╷
│ Error: Provider produced invalid plan
│
│ Provider "terraform.releases.teleport.dev/gravitational/teleport" planned an invalid value for teleport_role.test.spec.allow.node_labels: planned value
│ cty.MapVal(map[string]cty.Value{"env":cty.ListVal([]cty.Value{cty.StringVal("")})}) does not match config value
│ cty.MapVal(map[string]cty.Value{"env":cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)})}) nor prior value
│ cty.MapVal(map[string]cty.Value{"env":cty.ListVal([]cty.Value{cty.StringVal("dev")})}).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

</details>