### PR TITLE
Migrate nested attributes

### DIFF
--- a/examples/tfschema/objects/v1/objects_terraform.go
+++ b/examples/tfschema/objects/v1/objects_terraform.go
@@ -31,6 +31,10 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"
 	github_com_hashicorp_terraform_plugin_framework_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	github_com_hashicorp_terraform_plugin_framework_resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -57,13 +61,13 @@ func GenSchemaObjectsResource(ctx context.Context) (github_com_hashicorp_terrafo
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 		},
-		"branch_empty": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_empty": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "",
 			Optional:    true,
 		},
@@ -74,31 +78,31 @@ func GenSchemaObjectsResource(ctx context.Context) (github_com_hashicorp_terrafo
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
-		"branch_leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 				Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "",
 			Optional:    true,
 		},
-		"branch_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}},
 			Description: "",
 			Optional:    true,
 		},
@@ -116,13 +120,13 @@ func GenSchemaObjectsResource(ctx context.Context) (github_com_hashicorp_terrafo
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
-		"empty": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"empty": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "empty is an empty field.",
 			Optional:    true,
 		},
@@ -140,133 +144,133 @@ func GenSchemaObjectsResource(ctx context.Context) (github_com_hashicorp_terrafo
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.Int64Type},
 		},
-		"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 				Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Computed:      true,
 			Description:   "",
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
 		},
-		"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+			Computed:    true,
+			Description: "nested_list is a list of nested objects.",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
-			Computed:      true,
-			Description:   "nested_list is a list of nested objects.",
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 		},
-		"nested_map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_map": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+			Computed:    true,
+			Description: "nested_map is a map of nested objects.",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
-			Computed:      true,
-			Description:   "nested_map is a map of nested objects.",
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 		},
-		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}},
 			Description: "nested_nullable is a nullable nested object.",
 			Optional:    true,
 		},
-		"nested_nullable_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+			Computed:    true,
+			Description: "nested_nullable_list is a nullable list of nested objects.",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
-			Computed:      true,
-			Description:   "nested_nullable_list is a nullable list of nested objects.",
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 		},
-		"nested_nullable_map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable_map": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+			Computed:    true,
+			Description: "nested_map is a nullable map of nested objects.",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
-			Computed:      true,
-			Description:   "nested_map is a nullable map of nested objects.",
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 		},
-		"nested_value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_value": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "",
 					Optional:      true,
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:      true,
 				Description:   "",
 				Optional:      true,
-				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
-			}}),
+				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
+			}},
 			Computed:      true,
 			Description:   "nested_value is a nested object.",
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
 		},
-		"primitives": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"primitives": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"bool_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "bool_list bool list field.",
@@ -386,11 +390,11 @@ func GenSchemaObjectsResource(ctx context.Context) (github_com_hashicorp_terrafo
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Computed:      true,
 			Description:   "primitives field.",
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
 		},
 		"string_map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 			Computed:      true,
@@ -417,13 +421,13 @@ func GenSchemaObjectsDataSource(ctx context.Context) (github_com_hashicorp_terra
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 		},
-		"branch_empty": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_empty": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "",
 			Optional:    true,
 		},
@@ -433,28 +437,28 @@ func GenSchemaObjectsDataSource(ctx context.Context) (github_com_hashicorp_terra
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
-		"branch_leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "",
 			Optional:    true,
 		},
-		"branch_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:    true,
 				Description: "",
 				Optional:    true,
-			}}),
+			}},
 			Description: "",
 			Optional:    true,
 		},
@@ -470,13 +474,13 @@ func GenSchemaObjectsDataSource(ctx context.Context) (github_com_hashicorp_terra
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
-		"empty": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"empty": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "empty is an empty field.",
 			Optional:    true,
 		},
@@ -492,114 +496,114 @@ func GenSchemaObjectsDataSource(ctx context.Context) (github_com_hashicorp_terra
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.Int64Type},
 		},
-		"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Computed:    true,
 			Description: "",
 			Optional:    true,
 		},
-		"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
-				Computed:    true,
-				Description: "",
-				Optional:    true,
-			}}),
+		"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 			Computed:    true,
 			Description: "nested_list is a list of nested objects.",
-			Optional:    true,
-		},
-		"nested_map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:    true,
 				Description: "",
 				Optional:    true,
-			}}),
+			}}},
+			Optional: true,
+		},
+		"nested_map": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 			Computed:    true,
 			Description: "nested_map is a map of nested objects.",
-			Optional:    true,
-		},
-		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:    true,
 				Description: "",
 				Optional:    true,
-			}}),
+			}}},
+			Optional: true,
+		},
+		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				}},
+				Computed:    true,
+				Description: "",
+				Optional:    true,
+			}},
 			Description: "nested_nullable is a nullable nested object.",
 			Optional:    true,
 		},
-		"nested_nullable_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
-				Computed:    true,
-				Description: "",
-				Optional:    true,
-			}}),
+		"nested_nullable_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 			Computed:    true,
 			Description: "nested_nullable_list is a nullable list of nested objects.",
-			Optional:    true,
-		},
-		"nested_nullable_map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:    true,
 				Description: "",
 				Optional:    true,
-			}}),
+			}}},
+			Optional: true,
+		},
+		"nested_nullable_map": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 			Computed:    true,
 			Description: "nested_map is a nullable map of nested objects.",
-			Optional:    true,
-		},
-		"nested_value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				}}),
+				}},
 				Computed:    true,
 				Description: "",
 				Optional:    true,
-			}}),
+			}}},
+			Optional: true,
+		},
+		"nested_value": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"leaf": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+				Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				}},
+				Computed:    true,
+				Description: "",
+				Optional:    true,
+			}},
 			Computed:    true,
 			Description: "nested_value is a nested object.",
 			Optional:    true,
 		},
-		"primitives": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"primitives": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"bool_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "bool_list bool list field.",
@@ -702,7 +706,7 @@ func GenSchemaObjectsDataSource(ctx context.Context) (github_com_hashicorp_terra
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Computed:    true,
 			Description: "primitives field.",
 			Optional:    true,

--- a/field.go
+++ b/field.go
@@ -76,6 +76,12 @@ type TerraformType struct {
 	IsMessage bool
 	// TypeConstructor represents expression which is used to initialize type in schema
 	TypeConstructor string
+	// PlanModifierType represents Terraform planmodifier type
+	PlanModifierType string
+	// ValidatorType represents Terraform validator type
+	ValidatorType string
+	// UseStateForUnknownMethod is the method called to return UseStateForUnknown plan modifier
+	UseStateForUnknownMethod string
 }
 
 // ProtobufType represents protobuf object field type information
@@ -216,7 +222,7 @@ func BuildField(c *FieldBuildContext) ([]*Field, error) {
 		IsNullable:       c.GetNullable(),
 		IsProto3Optional: isProto3Optional,
 		Validators:       c.GetValidators(),
-		PlanModifiers:    c.GetPlanModifiers(isProto3Optional),
+		PlanModifiers:    c.GetPlanModifiers(),
 		Path:             c.GetPath(),
 		Comment:          c.GetComment(),
 	}
@@ -275,9 +281,21 @@ func BuildField(c *FieldBuildContext) ([]*Field, error) {
 	f.setTerraformTypeOverride(c)
 	f.setCustomType(c)
 
-	f.GoElemTypeIndirect = strings.Replace(f.GoElemType, "*", "", -1)
-
 	f.Kind = f.getKind()
+
+	// Set default UseStateForUnknown plan modifier for computed attributes
+	// when use_state_for_unknown_by_default=true.
+	if len(f.PlanModifiers) == 0 && c.config.UseStateForUnknownByDefault && c.IsComputed(isProto3Optional) {
+		// TODO: Remove deprecated plan modifier once all attributes are migrated
+		switch f.Kind {
+		case ObjectKind, ObjectListKind, ObjectMapKind:
+			f.PlanModifiers = append(f.PlanModifiers, f.UseStateForUnknownMethod)
+		default:
+			f.PlanModifiers = append(f.PlanModifiers, "github.com/hashicorp/terraform-plugin-framework/resource.UseStateForUnknown()")
+		}
+	}
+
+	f.GoElemTypeIndirect = strings.Replace(f.GoElemType, "*", "", -1)
 
 	isOneOf, err := c.IsOneOf()
 	if err != nil {

--- a/field_build_context.go
+++ b/field_build_context.go
@@ -89,10 +89,13 @@ var (
 	}
 
 	objectType = TerraformType{
-		Type:          Types + ".ObjectType",
-		ValueType:     Types + ".Object",
-		ElemType:      Types + ".ObjectType",
-		ElemValueType: Types + ".Object",
+		Type:                     Types + ".ObjectType",
+		ValueType:                Types + ".Object",
+		ElemType:                 Types + ".ObjectType",
+		ElemValueType:            Types + ".Object",
+		PlanModifierType:         PlanModifier + ".Object",
+		ValidatorType:            Validator + ".Object",
+		UseStateForUnknownMethod: ResourceSchema + "/objectplanmodifier.UseStateForUnknown()",
 	}
 )
 
@@ -307,11 +310,17 @@ func (c *FieldBuildContext) GetTerraformType() (TerraformType, error) {
 	if c.IsRepeated() {
 		t.Type = Types + ".ListType"
 		t.ValueType = Types + ".List"
+		t.PlanModifierType = PlanModifier + ".List"
+		t.ValidatorType = Validator + ".List"
+		t.UseStateForUnknownMethod = ResourceSchema + "/listplanmodifier.UseStateForUnknown()"
 	}
 
 	if c.IsMap() {
 		t.Type = Types + ".MapType"
 		t.ValueType = Types + ".Map"
+		t.PlanModifierType = PlanModifier + ".Map"
+		t.ValidatorType = Validator + ".Map"
+		t.UseStateForUnknownMethod = ResourceSchema + "/mapplanmodifier.UseStateForUnknown()"
 	}
 
 	if c.IsCastType() {
@@ -507,7 +516,7 @@ func (c *FieldBuildContext) GetValidators() []string {
 }
 
 // GetPlanModifiers returns field validators
-func (c *FieldBuildContext) GetPlanModifiers(isProto3Optional bool) []string {
+func (c *FieldBuildContext) GetPlanModifiers() []string {
 	v, ok := c.config.PlanModifiers[c.GetPath()]
 	if !ok {
 		v, ok = c.config.PlanModifiers[c.GetNameWithTypeName()]
@@ -515,10 +524,6 @@ func (c *FieldBuildContext) GetPlanModifiers(isProto3Optional bool) []string {
 
 	if ok {
 		return v
-	}
-
-	if c.config.UseStateForUnknownByDefault && c.IsComputed(isProto3Optional) {
-		return []string{"github.com/hashicorp/terraform-plugin-framework/resource.UseStateForUnknown()"}
 	}
 
 	return []string{}

--- a/gen_schema.go
+++ b/gen_schema.go
@@ -151,6 +151,90 @@ func NewFieldSchemaGenerator(f *Field, i *Imports, target schemaTarget) *FieldSc
 
 // Generate returns field schema
 func (f *FieldSchemaGenerator) Generate() *j.Statement {
+	dict := f.baseAttributeDict()
+
+	switch f.Kind {
+	case ObjectKind:
+		return f.genSingleNestedAttribute(dict)
+	case ObjectListKind:
+		return f.genListNestedAttribute(dict)
+	case ObjectMapKind:
+		return f.genMapNestedAttribute(dict)
+	default:
+		return f.genLegacy()
+	}
+}
+
+func (f *FieldSchemaGenerator) baseAttributeDict() j.Dict {
+	d := j.Dict{
+		j.Id("Description"): j.Lit(f.Comment),
+	}
+
+	// Required/Optional
+	if f.IsRequired {
+		d[j.Id("Required")] = j.True()
+	} else {
+		d[j.Id("Optional")] = j.True()
+	}
+
+	// Sensitive
+	if f.IsSensitive {
+		d[j.Id("Sensitive")] = j.True()
+	}
+
+	// Computed
+	if f.IsComputed {
+		d[j.Id("Computed")] = j.True()
+	}
+
+	// Validators
+	if len(f.Validators) > 0 {
+		d[j.Id("Validators")] = generateValidatorsWithType(
+			f.i,
+			f.ValidatorType,
+			f.Validators)
+	}
+
+	// Plan modifiers
+	if f.target.supportsPlanModifiers && len(f.PlanModifiers) > 0 {
+		d[j.Id("PlanModifiers")] = generatePlanModifiersWithType(
+			f.i,
+			f.PlanModifierType,
+			f.PlanModifiers)
+	}
+
+	return d
+}
+
+func (f *FieldSchemaGenerator) nestedAttributes(m *MessageSchemaGenerator) *j.Statement {
+	fieldsDict := m.fieldsDictSchema()
+	return j.Map(j.String()).Id(f.i.WithPackage(f.target.schemaPackage, "Attribute")).Values(fieldsDict)
+}
+
+func (f *FieldSchemaGenerator) genSingleNestedAttribute(d j.Dict) *j.Statement {
+	m := NewMessageSchemaGenerator(f.Message, f.i, f.target)
+	nestedAttributes := f.nestedAttributes(m)
+	d[j.Id("Attributes")] = nestedAttributes
+	return j.Id(f.i.WithPackage(f.target.schemaPackage, "SingleNestedAttribute")).Values(d)
+}
+
+func (f *FieldSchemaGenerator) genListNestedAttribute(d j.Dict) *j.Statement {
+	m := NewMessageSchemaGenerator(f.Message, f.i, f.target)
+	nestedAttributes := f.nestedAttributes(m)
+	d[j.Id("NestedObject")] = j.Id(f.i.WithPackage(f.target.schemaPackage, "NestedAttributeObject")).
+		Values(j.Dict{j.Id("Attributes"): nestedAttributes})
+	return j.Id(f.i.WithPackage(f.target.schemaPackage, "ListNestedAttribute")).Values(d)
+}
+
+func (f *FieldSchemaGenerator) genMapNestedAttribute(d j.Dict) *j.Statement {
+	m := NewMessageSchemaGenerator(f.MapValueField.Message, f.i, f.target)
+	nestedAttributes := f.nestedAttributes(m)
+	d[j.Id("NestedObject")] = j.Id(f.i.WithPackage(f.target.schemaPackage, "NestedAttributeObject")).
+		Values(j.Dict{j.Id("Attributes"): nestedAttributes})
+	return j.Id(f.i.WithPackage(f.target.schemaPackage, "MapNestedAttribute")).Values(d)
+}
+
+func (f *FieldSchemaGenerator) genLegacy() *j.Statement {
 	d := j.Dict{
 		j.Id("Description"): j.Lit(f.Comment),
 		j.Id("Type"):        f.schemaType(), // nils are automatically omitted
@@ -269,4 +353,22 @@ func generateValidators(imports *Imports, vals []string) j.Code {
 	}
 
 	return j.Index().Id(imports.WithPackage(SDK, "AttributeValidator")).Values(v...)
+}
+
+func generatePlanModifiersWithType(imports *Imports, planModifierType string, pm []string) j.Code {
+	v := make([]jen.Code, len(pm))
+	for i, n := range pm {
+		v[i] = j.Id(imports.WithType(n))
+	}
+
+	return j.Index().Id(imports.WithType(planModifierType)).Values(v...)
+}
+
+func generateValidatorsWithType(imports *Imports, validatorType string, vals []string) j.Code {
+	v := make([]jen.Code, len(vals))
+	for i, n := range vals {
+		v[i] = j.Id(imports.WithType(n))
+	}
+
+	return j.Index().Id(imports.WithType(validatorType)).Values(v...)
 }

--- a/imports.go
+++ b/imports.go
@@ -35,6 +35,10 @@ const (
 	DataSourceSchema = "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	// ResourceSchema represents the path to the Terraform resource schema package
 	ResourceSchema = "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	// PlanModifier represents the path to the Terraform planmodifier package
+	PlanModifier = "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	// Validator represents the path to the Terraform validator package
+	Validator = "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 // Imports represents the collection of imports and acts as the facade for generator.PluginImports

--- a/test/optional/optional_terraform.go
+++ b/test/optional/optional_terraform.go
@@ -57,12 +57,12 @@ func GenSchemaOptionalTestResource(ctx context.Context) (github_com_hashicorp_te
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 		},
-		"optional_inner_message": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"inner_bool": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"optional_inner_message": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"inner_bool": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Description: "",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "OptionalInnerMessage is a proto3 optional message field",
 			Optional:    true,
 		},
@@ -111,12 +111,12 @@ func GenSchemaOptionalTestDataSource(ctx context.Context) (github_com_hashicorp_
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
 		},
-		"optional_inner_message": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"inner_bool": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"optional_inner_message": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"inner_bool": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Description: "",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "OptionalInnerMessage is a proto3 optional message field",
 			Optional:    true,
 		},

--- a/test/test_terraform.go
+++ b/test/test_terraform.go
@@ -31,6 +31,10 @@ import (
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"
 	github_com_hashicorp_terraform_plugin_framework_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	github_com_hashicorp_terraform_plugin_framework_resource_schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	_ "google.golang.org/protobuf/types/known/timestamppb"
@@ -65,25 +69,25 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 			Optional:      true,
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 		}),
-		"branch1": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch1": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:      true,
 				Description:   "Str string field",
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 				Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "Branch1 is the first oneOf branch",
 			Optional:    true,
 		},
-		"branch2": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"int32": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch2": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"int32": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:      true,
 				Description:   "Int32 int field",
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 				Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
-			}}),
+			}},
 			Description: "Branch2 is the second oneOf branch",
 			Optional:    true,
 		},
@@ -150,14 +154,14 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          DurationType{},
 		},
-		"embedded_nested_field": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"embedded_nested_string": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"embedded_nested_field": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"embedded_nested_string": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:      true,
 				Description:   "EmbeddedNestedString string field",
 				Optional:      true,
 				PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 				Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "Nested EmbeddedNestedField field",
 			Optional:    true,
 		},
@@ -168,13 +172,13 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
-		"empty_message_branch": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"empty_message_branch": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "EmptyMessageBranch is the oneof branch triggered by empty message",
 			Optional:    true,
 		},
@@ -219,8 +223,10 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 		},
-		"map_object": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"map_object": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+			Computed:    true,
+			Description: "MapObject is the object map",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -228,31 +234,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -261,14 +267,14 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
-			Computed:      true,
-			Description:   "MapObject is the object map",
+			}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 		},
-		"map_object_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"map_object_nullable": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+			Computed:    true,
+			Description: "MapObjectNullable is the object map with nullable values",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -276,31 +282,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -309,11 +315,9 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
-			Computed:      true,
-			Description:   "MapObjectNullable is the object map with nullable values",
+			}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 		},
 		"max_age": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 			Computed:      true,
@@ -329,8 +333,8 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 			Type:          github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
-		"nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -338,31 +342,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -371,14 +375,16 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Computed:      true,
 			Description:   "Nested nested message field, non-nullable",
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Object{github_com_hashicorp_terraform_plugin_framework_resource_schema_objectplanmodifier.UseStateForUnknown()},
 		},
-		"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+			Computed:    true,
+			Description: "NestedList nested message array",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -386,31 +392,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -419,14 +425,14 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
-			Computed:      true,
-			Description:   "NestedList nested message array",
+			}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 		},
-		"nested_list_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_list_nullable": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+			Computed:    true,
+			Description: "NestedListNullable nested message array",
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -434,31 +440,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -467,14 +473,12 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
-			Computed:      true,
-			Description:   "NestedListNullable nested message array",
+			}},
 			Optional:      true,
-			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+			PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 		},
-		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -482,31 +486,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -515,12 +519,12 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Description: "NestedNullable nested message field, nullable",
 			Optional:    true,
 		},
-		"nested_nullable_with_nil_value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable_with_nil_value": github_com_hashicorp_terraform_plugin_framework_resource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
 					Description:   "Nested map repeated nested messages",
@@ -528,31 +532,31 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_resource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "MapObjectNested nested object map",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.Map{github_com_hashicorp_terraform_plugin_framework_resource_schema_mapplanmodifier.UseStateForUnknown()},
 				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_resource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_resource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_resource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:      true,
 						Description:   "Str string field",
 						Optional:      true,
 						PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 						Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:      true,
-					Description:   "Nested repeated nested messages",
+					}}},
 					Optional:      true,
-					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_resource_schema_planmodifier.List{github_com_hashicorp_terraform_plugin_framework_resource_schema_listplanmodifier.UseStateForUnknown()},
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:      true,
@@ -561,7 +565,7 @@ func GenSchemaTestResource(ctx context.Context) (github_com_hashicorp_terraform_
 					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_resource.UseStateForUnknown()},
 					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Description: "NestedNullableWithNilValue nested message field, with no value set",
 			Optional:    true,
 		},
@@ -667,23 +671,23 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 			Description: "BoolCustomList []bool field",
 			Optional:    true,
 		}),
-		"branch1": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch1": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Str string field",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "Branch1 is the first oneOf branch",
 			Optional:    true,
 		},
-		"branch2": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"int32": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"branch2": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"int32": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Int32 int field",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
-			}}),
+			}},
 			Description: "Branch2 is the second oneOf branch",
 			Optional:    true,
 		},
@@ -741,13 +745,13 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 			Optional:    true,
 			Type:        DurationType{},
 		},
-		"embedded_nested_field": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"embedded_nested_string": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"embedded_nested_field": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"embedded_nested_string": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "EmbeddedNestedString string field",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-			}}),
+			}},
 			Description: "Nested EmbeddedNestedField field",
 			Optional:    true,
 		},
@@ -757,13 +761,13 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
-		"empty_message_branch": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"empty_message_branch": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"active": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				Computed:    true,
 				Description: "Automatically generated field preventing empty message errors",
 				Optional:    true,
 				Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
-			}}),
+			}},
 			Description: "EmptyMessageBranch is the oneof branch triggered by empty message",
 			Optional:    true,
 		},
@@ -803,76 +807,37 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 		},
-		"map_object": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
-				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:    true,
-					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:    true,
-					Description: "Nested repeated nested messages",
-					Optional:    true,
-				},
-				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "Str string field",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-			}),
+		"map_object": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 			Computed:    true,
 			Description: "MapObject is the object map",
-			Optional:    true,
-		},
-		"map_object_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "Nested map repeated nested messages",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 					Computed:    true,
 					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:    true,
 						Description: "Str string field",
 						Optional:    true,
 						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 					Computed:    true,
 					Description: "Nested repeated nested messages",
-					Optional:    true,
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
@@ -880,10 +845,49 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			}},
+			Optional: true,
+		},
+		"map_object_nullable": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 			Computed:    true,
 			Description: "MapObjectNullable is the object map with nullable values",
-			Optional:    true,
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
+				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "Nested map repeated nested messages",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+				},
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
+				},
+				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "Str string field",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				},
+			}},
+			Optional: true,
 		},
 		"max_age": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 			Computed:    true,
@@ -897,35 +901,35 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 			Optional:    true,
 			Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 		},
-		"nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "Nested map repeated nested messages",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 					Computed:    true,
 					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:    true,
 						Description: "Str string field",
 						Optional:    true,
 						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 					Computed:    true,
 					Description: "Nested repeated nested messages",
-					Optional:    true,
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
@@ -933,81 +937,42 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Computed:    true,
 			Description: "Nested nested message field, non-nullable",
 			Optional:    true,
 		},
-		"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "Nested map repeated nested messages",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
-				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:    true,
-					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
-					Computed:    true,
-					Description: "Nested repeated nested messages",
-					Optional:    true,
-				},
-				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Computed:    true,
-					Description: "Str string field",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-				},
-			}),
+		"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 			Computed:    true,
 			Description: "NestedList nested message array",
-			Optional:    true,
-		},
-		"nested_list_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "Nested map repeated nested messages",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 					Computed:    true,
 					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:    true,
 						Description: "Str string field",
 						Optional:    true,
 						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 					Computed:    true,
 					Description: "Nested repeated nested messages",
-					Optional:    true,
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
@@ -1015,40 +980,40 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			}},
+			Optional: true,
+		},
+		"nested_list_nullable": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 			Computed:    true,
 			Description: "NestedListNullable nested message array",
-			Optional:    true,
-		},
-		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "Nested map repeated nested messages",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 					Computed:    true,
 					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:    true,
 						Description: "Str string field",
 						Optional:    true,
 						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 					Computed:    true,
 					Description: "Nested repeated nested messages",
-					Optional:    true,
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
@@ -1056,39 +1021,78 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			}},
+			Optional: true,
+		},
+		"nested_nullable": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
+				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "Nested map repeated nested messages",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
+				},
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
+					Computed:    true,
+					Description: "MapObjectNested nested object map",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
+					Computed:    true,
+					Description: "Nested repeated nested messages",
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
+				},
+				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					Computed:    true,
+					Description: "Str string field",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				},
+			},
 			Description: "NestedNullable nested message field, nullable",
 			Optional:    true,
 		},
-		"nested_nullable_with_nil_value": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+		"nested_nullable_with_nil_value": github_com_hashicorp_terraform_plugin_framework_datasource_schema.SingleNestedAttribute{
+			Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{
 				"map": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
 					Description: "Nested map repeated nested messages",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.MapType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 				},
-				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-						Computed:    true,
-						Description: "Str string field",
-						Optional:    true,
-						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+				"map_object_nested": github_com_hashicorp_terraform_plugin_framework_datasource_schema.MapNestedAttribute{
 					Computed:    true,
 					Description: "MapObjectNested nested object map",
-					Optional:    true,
-				},
-				"nested_list": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 						Computed:    true,
 						Description: "Str string field",
 						Optional:    true,
 						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-					}}),
+					}}},
+					Optional: true,
+				},
+				"nested_list": github_com_hashicorp_terraform_plugin_framework_datasource_schema.ListNestedAttribute{
 					Computed:    true,
 					Description: "Nested repeated nested messages",
-					Optional:    true,
+					NestedObject: github_com_hashicorp_terraform_plugin_framework_datasource_schema.NestedAttributeObject{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_datasource_schema.Attribute{"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						Computed:    true,
+						Description: "Str string field",
+						Optional:    true,
+						Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					}}},
+					Optional: true,
 				},
 				"str": github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 					Computed:    true,
@@ -1096,7 +1100,7 @@ func GenSchemaTestDataSource(ctx context.Context) (github_com_hashicorp_terrafor
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
-			}),
+			},
 			Description: "NestedNullableWithNilValue nested message field, with no value set",
 			Optional:    true,
 		},


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/42445

`terraform-plugin-framework` v.0.17.0 deprecates `tfsdk.Attribute`. Instead use
- `schema.SingleNestedAttribute`
- `schema.ListNestedAttribute`
- `schema.MapNestedAttribute`  

See [https://github.com/hashicorp/terraform-plugin-framework/releases/tag/v0.17.0](https://github.com/hashicorp/terraform-plugin-framework/releases/tag/v0.17.0)